### PR TITLE
Hid sets from catalog controller results.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -20,9 +20,25 @@ class CatalogController < ApplicationController
   # Filter out unreviewed items.
   self.solr_search_params_logic += [:exclude_unreviewed_items]
 
+  def exclude_unwanted_models(solr_parameters, user_parameters)
+    solr_parameters[:fq] ||= []
+    unwanted_models.each do |model|
+      solr_parameters[:fq] << "-#{ActiveFedora::SolrService.solr_name("active_fedora_model", :stored_sortable)}:\"#{model.to_s}\""
+    end
+  end
+
   def exclude_unreviewed_items(solr_parameters, user_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << "-#{ActiveFedora::SolrService.solr_name(:reviewed, :symbol)}:\"false\""
+  end
+
+  private
+
+  # Array of models to exclude from catalog results.
+  def unwanted_models
+    [
+      GenericCollection
+    ]
   end
 
 end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'catalog' do
+  describe 'search results' do
+    context "when there is a collection" do
+      before(:each) do
+        @collection = GenericCollection.new
+        @collection.title = "Test Collection"
+        @collection.read_groups = ["public"]
+        @collection.review!
+      end
+      it "should not show up in search results" do
+        visit root_path(:search_field => "all_field")
+        expect(page).not_to have_selector('.document')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We may undo this later if we decide that sets should be shown.
