### PR TITLE
Fix role management

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,0 +1,8 @@
+class RolesController < ApplicationController
+  before_filter :load_role, :only => [:create]
+  include Hydra::RoleManagement::RolesBehavior
+
+  def load_role
+    @role = Role.new(role_params)
+  end
+end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe "Role management" do
+  let(:user) { FactoryGirl.create(:admin) }
+
+  before(:each) do
+    capybara_login(user)
+    visit root_path
+
+    within(".utils .admin") do
+      click_link "Roles"
+    end
+  end
+
+  it "should allow an admin to create a role" do
+    click_button "Create a new role"
+    fill_in "Role name", :with => "foo"
+    click_button "Create Role"
+
+    # We have two because the factory created one for us to use with login
+    expect(Role.count).to eq(2)
+    expect(Role.first.name).to eq("admin")
+    expect(Role.last.name).to eq("foo")
+  end
+end


### PR DESCRIPTION
closes #217 

This is a temporary fix.  A new ticket has been filed for figuring out why we have this issue when other Hydra users don't appear to (or at least they haven't filed tickets about it).
