### PR TITLE
Display "LC Subject" instead of "Lcsubject"

### DIFF
--- a/app/decorators/generic_asset_decorator.rb
+++ b/app/decorators/generic_asset_decorator.rb
@@ -18,7 +18,7 @@ class GenericAssetDecorator < Draper::Decorator
   end
 
   def field_label(field)
-    I18n.t("oregondigital.catalog.show.#{field.downcase}", :default => field.humanize)
+    OregonDigital::Metadata::FieldTypeLabel.for(field)
   end
 
   def field_values(field)
@@ -47,7 +47,7 @@ class GenericAssetDecorator < Draper::Decorator
   end
 
   def configured_show_keys
-    r = I18n.t("oregondigital.catalog.show")
+    r = I18n.t("oregondigital.metadata")
     r = {} unless r.kind_of?(Hash)
     r.keys.map{|x| x.to_s.downcase}
   end

--- a/app/helpers/ingest_helper.rb
+++ b/app/helpers/ingest_helper.rb
@@ -15,9 +15,14 @@ module IngestHelper
   def type_value_fields(f)
     controls = []
 
+    options_values = INGEST_MAP[f.object.group.to_sym].keys
+    options = options_values.collect do |val|
+      [OregonDigital::Metadata::FieldTypeLabel.for(val.to_s), val]
+    end
+
     controls << f.input(
       :type,
-      :collection => INGEST_MAP[f.object.group.to_sym].keys,
+      :collection => options,
       :input_html => {:class => "input-medium type-selector"},
       :label_html => {:class => "sr-only"},
       :wrapper_html => {:class => "ingest-control type"}

--- a/config/locales/oregondigital.en.yml
+++ b/config/locales/oregondigital.en.yml
@@ -1,9 +1,11 @@
 en:
   oregondigital:
+    metadata:
+      title: Title
+      lcsubject: LC Subject
+
     catalog:
-      show:
-        title: Title
       facet:
-        subject: Topic
+        lcsubject: Topic
         location: Region
         set: Collection

--- a/lib/oregon_digital/catalog/index_fields.rb
+++ b/lib/oregon_digital/catalog/index_fields.rb
@@ -6,9 +6,10 @@ module OregonDigital
         configure_blacklight do |config|
           # solr fields to be displayed in the index (search results) view
           #   The ordering of the field names is the order of the display
-          config.add_index_field solr_name('desc_metadata__subject_label', :displayable), :label => 'Subject:', :helper_method => :controlled_view_label
-          config.add_index_field solr_name('desc_metadata__description', :displayable), :label => 'Description:'
-          config.add_index_field solr_name('desc_metadata__modified', :displayable), :label => 'Record Modified:'
+          for field in [:description, :modified]
+            label = OregonDigital::Metadata::FieldTypeLabel.for(field)
+            config.add_index_field solr_name("desc_metadata__#{field}", :displayable), :label => label
+          end
         end
       end
     end

--- a/lib/oregon_digital/metadata/field_type_label.rb
+++ b/lib/oregon_digital/metadata/field_type_label.rb
@@ -1,0 +1,7 @@
+class OregonDigital::Metadata::FieldTypeLabel
+  # Returns the label for the given internal field name (the value in an
+  # options dropdown, which is also the "type" on the ingest map)
+  def self.for(field)
+    I18n.t(field, :scope => [:oregondigital, :metadata], :default => field.to_s.humanize)
+  end
+end

--- a/spec/decorators/generic_asset_decorator_spec.rb
+++ b/spec/decorators/generic_asset_decorator_spec.rb
@@ -27,7 +27,7 @@ describe GenericAssetDecorator do
         end
         before(:each) do
           I18n.stub(:t).and_call_original
-          I18n.stub(:t).with("oregondigital.catalog.show").and_return({:photographer => "photographer", :created => "created"})
+          I18n.stub(:t).with("oregondigital.metadata").and_return({:photographer => "photographer", :created => "created"})
         end
         it "should organize those fields at the top in the given order" do
           expect(result).to eq ["photographer", "created", "title"]

--- a/spec/features/show_fields_spec.rb
+++ b/spec/features/show_fields_spec.rb
@@ -64,8 +64,7 @@ describe "show fields" do
     end
     context "and a label is configured" do
       let(:stub_setup) do
-        I18n.stub(:t).and_call_original
-        I18n.stub(:t).with("oregondigital.catalog.show.title", {:default => "Title"}).and_return("Test Title")
+        I18n.backend.send(:translations)[:en][:oregondigital][:metadata][:title] = "Test Title"
       end
       it "should display it" do
         expect(page).to have_content("Test Title")

--- a/spec/support/ingest_form.rb
+++ b/spec/support/ingest_form.rb
@@ -19,6 +19,7 @@ def ingest_group_nodes(group)
 end
 
 def fill_in_ingest_data(group, type, value, position = 0, clone = false)
+  type = OregonDigital::Metadata::FieldTypeLabel.for(type)
   nodes = ingest_group_nodes(group)
   node = nodes[position]
   within(node) do
@@ -37,6 +38,8 @@ end
 def choose_controlled_vocabulary_item(group, type, search, pick, internal, position = 0)
   # Expectations are here to ensure tests for CV stuff stay solid
   expect(page).not_to have_content(pick)
+
+  type = OregonDigital::Metadata::FieldTypeLabel.for(type)
 
   group_div = ingest_group_nodes(group)[position]
   group_div.select(type, :from => "Type")


### PR DESCRIPTION
- Moves metadata-related I18n rules to more generic location
- Adds new class to centralize I18n pull of field label
- Uses central label algorithm on the search, show view, and ingest form
- Removes subject from search results per requirements
- Fixes faceting to use "lcsubject" field as "Topic"

closes #260 
