### PR TITLE
adding institution attribute to GenericCollection for future convenience

### DIFF
--- a/app/models/generic_asset.rb
+++ b/app/models/generic_asset.rb
@@ -24,7 +24,7 @@ class GenericAsset < ActiveFedora::Base
   end
 
   has_attributes :format, :type, :location, :created, :description, :rights, :title, :modified, :date, :datastream => :descMetadata, :multiple => false
-  has_attributes :identifier, :lcsubject, :set, :creator, :contributor, :datastream => :descMetadata, :multiple => true
+  has_attributes :identifier, :lcsubject, :set, :creator, :contributor, :institution, :datastream => :descMetadata, :multiple => true
 
   private
 

--- a/spec/models/generic_collection_spec.rb
+++ b/spec/models/generic_collection_spec.rb
@@ -23,5 +23,8 @@ describe GenericCollection do
       subject.save
       expect(subject.resource.rdf_subject.to_s).to start_with "http://oregondigital.org/resource/"
     end
+    it "should have an insitution attribute" do
+      expect(subject).to respond_to :institution
+    end
   end
 end


### PR DESCRIPTION
This is probably worth a moment of discussion.  This attribute could go into GenericAsset, and putting it in the subclass sets a precedent that attributes can be extended.  

So this is proposed.  Looking for a +1.
