### PR TITLE
Make all the routes use /catalog instead of /.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Oregondigital::Application.routes.draw do
-  root :to => "catalog#index"
-
+  root :to => redirect { |params, request| "/catalog?#{request.params.to_query}"}
   Blacklight.add_routes(self)
   HydraHead.add_routes(self)
 

--- a/spec/features/collection_facets_spec.rb
+++ b/spec/features/collection_facets_spec.rb
@@ -79,6 +79,9 @@ describe 'collection facets' do
         visit root_path
         click_link item.lcsubject.first.rdf_label.first
       end
+      it "should go to /catalog" do
+        expect(current_path).to include "catalog"
+      end
       context "and then the collection facet is clicked" do
         before(:each) do
           click_link collection.title


### PR DESCRIPTION
This is necessary only while we have ContentDM and Hydra running
side-by-side.
