### PR TITLE
Bookreader Improvements

### DIFF
--- a/app/assets/javascripts/bookreader/oregondigital_bookreader.js.coffee
+++ b/app/assets/javascripts/bookreader/oregondigital_bookreader.js.coffee
@@ -25,6 +25,7 @@ class BookReaderManager
     @br.bookTitle = @element.data("title")
     @br.bookUrl = ''
     @br.getEmbedCode = -> return "Embedding is disabled."
+    @br.reductionFactors = this.reductionFactors()
     @br.init()
     $('#BRtoolbar').find('.read').hide()
     $('#textSrch').hide()
@@ -32,8 +33,20 @@ class BookReaderManager
     $('button.share').hide()
     $('button.info').hide()
     return @br
+  reductionFactors: ->
+    [{reduce: 0.25, autofit: null},
+      {reduce: 0.5, autofit: null},
+        {reduce: 1, autofit: null},
+        {reduce: 2, autofit: null},
+        {reduce: 3, autofit: null},
+        {reduce: 4, autofit: null},
+        {reduce: 6, autofit: null} ];
   getPageURI: (index, reduce, rotate) =>
-    "#{@element.data("root")}/page-#{index+1}.png"
+    reduce_factor = "small" if reduce >= 4
+    reduce_factor ||= "normal" if reduce >= 1
+    reduce_factor ||= "large" if reduce > 0.5
+    reduce_factor ||= "x-large"
+    "#{@element.data("root")}/#{reduce_factor}-page-#{index+1}.jpg"
   getPageSide: (index) ->
     if 0 == (index & 0x1)
       return'R'

--- a/app/models/datastream/yaml.rb
+++ b/app/models/datastream/yaml.rb
@@ -40,6 +40,7 @@ class Datastream::Yaml < ActiveFedora::Datastream
   end
 
   def to_solr(solr_doc = Hash.new,item=nil,term_prefix=nil)
+    item ||= {} if inner_hash.kind_of?(String)
     item ||= inner_hash.to_h
     item.each do |key, value|
       term_key = prefix(key,term_prefix)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,7 +10,7 @@ class Document < GenericAsset
   end
 
   def update_leaf_metadata
-    leafMetadata_content = DocumentMetadataGenerator.call(self.decorate).to_yaml
+    leafMetadata_content = DocumentMetadataGenerator.call(self.decorate, :skip_preload => true).to_yaml
     leafMetadata.content = leafMetadata_content unless leafMetadata_content.blank?
   end
 

--- a/app/services/document_metadata_generator.rb
+++ b/app/services/document_metadata_generator.rb
@@ -1,19 +1,25 @@
 class DocumentMetadataGenerator
   attr_accessor :document
   
-  def self.call(document)
-    new(document).metadata
+  def self.call(document, opts={})
+    new(document, opts).metadata
   end
 
-  def initialize(document)
+  def initialize(document, opts={})
     @document = document
-    preload_metadata
+    preload_metadata unless opts[:skip_preload]
   end
 
   def preload_metadata
-    unless document.leafMetadata.inner_hash.to_h.blank?
+    unless preloaded_data.to_h.blank?
       @document_metadata = document.leafMetadata.inner_hash.to_h.stringify_keys
     end
+  end
+
+  def preloaded_data
+    preloaded_data = document.leafMetadata.inner_hash
+    return {} if preloaded_data.blank?
+    preloaded_data
   end
 
   def metadata
@@ -58,7 +64,7 @@ class DocumentMetadataGenerator
     end
 
     def page_path
-      document.pages_location.join(page[0]+".png")
+      document.pages_location.join("normal-"+page[0]+".jpg")
     end
   end
 end

--- a/spec/controllers/document_controller_spec.rb
+++ b/spec/controllers/document_controller_spec.rb
@@ -21,7 +21,7 @@ describe DocumentController do
           expect(json['pages'].length).to eq 2
         end
         it "should have size data" do
-          expect(json['pages']).to eq [{"size" => {"width" => 1000, "height" => 1254}}, {"size" => {"width" => 1000, "height" => 1254}}]
+          expect(json['pages']).to eq [{"size" => {"width" => 500, "height" => 627}}, {"size" => {"width" => 500, "height" => 627}}]
         end
       end
     end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -27,7 +27,7 @@ describe Document do
       it "should create a derivative per page" do
         (1..2).each do |page|
           expect(document.datastreams.keys).to include("page-#{page}")
-          expect(document.datastreams["page-#{page}"].dsLocation).to eq "file://#{document.pages_location}/page-#{page}.png"
+          expect(document.datastreams["page-#{page}"].dsLocation).to eq "file://#{document.pages_location}/normal-page-#{page}.jpg"
           expect(Document.find(document.pid).datastreams.keys).to include("page-#{page}")
         end
       end

--- a/vendor/assets/stylesheets/bookreader/bookreader.css
+++ b/vendor/assets/stylesheets/bookreader/bookreader.css
@@ -899,11 +899,11 @@ div#BRzoombtn {
     display: none;
 }
 .BRup {
-    background-image: url("bookreader/images/nav_control-up.png");
+    background-image: url("/assets/bookreader/images/nav_control-up.png");
     background-repeat: no-repeat;
 }
 .BRdn {
-    background-image: url("bookreader/images/nav_control-dn.png");
+    background-image: url("/assets/bookreader/images/nav_control-dn.png");
     background-repeat: no-repeat;
 }
 #BRnavCntlBtm.BRup,#BRnavCntlBtm.BRdn {


### PR DESCRIPTION
Fixes bookreader assets for development, hides useless buttons, fixes two page view, and improves how the document loads images.

The second part is the biggest - this generates more derivatives per page in order to select the most appropriate size for their current zoom level. If they need more detail it ships up a bigger file for them to zoom in on.
