### PR TITLE
Fixing directory and absolute_directory on BulkTask

### DIFF
--- a/app/models/bulk_task.rb
+++ b/app/models/bulk_task.rb
@@ -10,7 +10,7 @@ class BulkTask < ActiveRecord::Base
   def self.refresh
     folders = Dir.glob(File.join(APP_CONFIG.batch_dir, '*')).select { |f| File.directory? f }
     (folders - BulkTask.pluck(:directory)).each do |dir|
-      dir = Pathname(dir).to_s
+      dir = Pathname(dir).relative_path_from(Pathname((APP_CONFIG.batch_dir))).to_s
       BulkTask.new(:directory => dir).save
     end
     # queue validation on tasks if they are new
@@ -46,12 +46,12 @@ class BulkTask < ActiveRecord::Base
   end
 
   def type
-    @type ||= :csv unless Dir.glob(File.join(absolute_path, '*.csv')).nil?
+    @type ||= :csv unless Dir.glob(File.join(absolute_path, '*.csv')).empty?
     @type ||= :bag
   end
 
   def absolute_path
-    File.join(APP_CONFIG.batch_dir, directory)
+    Pathname(directory).absolute? ? directory : File.join(APP_CONFIG.batch_dir, directory)
   end
 
   def enqueue

--- a/spec/models/bulk_task_spec.rb
+++ b/spec/models/bulk_task_spec.rb
@@ -58,6 +58,11 @@ describe BulkTask do
       BulkTask.refresh
       expect(BulkTask.all).to have(3).items
     end
+    
+    it 'assigns a relative directory' do
+      BulkTask.refresh
+      expect(Pathname(BulkTask.first.directory)).to be_relative
+    end
 
     it 'does not create duplicate BulkTasks' do
       BulkTask.new(:directory => File.join(APP_CONFIG.batch_dir, 'test1')).save
@@ -217,7 +222,7 @@ describe BulkTask do
 
   context 'with bag batch' do
     before do
-      Dir.stub(:glob).with(File.join(subject.absolute_path, '*.csv')).and_return(nil)
+      Dir.stub(:glob).with(File.join(subject.absolute_path, '*.csv')).and_return([])
     end
 
     it 'has bag type' do


### PR DESCRIPTION
BulkTask#refresh now sets the directory attribute to a relative path
from the configured bulk upload directory, and #absolute_path now only
prepends the base dir if the 'directory' path is relative.
