### PR TITLE
Allowance for bulk bag ingest if file type doesn't exist.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,11 @@ Oregondigital::Application.routes.draw do
   end
 
   # Reviewer Controller Routes
-  resources :reviewer, :only => [:index, :show, :update]
+  resources :reviewer, :only => [:index, :show, :update] do
+    collection do
+      get 'facet/:id', :to => "reviewer#facet"
+    end
+  end
 
   # Contact Form Routes
   post '/contact' => 'contact_form#create', :as => :contact_form_index

--- a/lib/oregon_digital/bag_ingestible.rb
+++ b/lib/oregon_digital/bag_ingestible.rb
@@ -3,7 +3,19 @@ module OregonDigital
     def bulk_ingest_bags(dir)
       assets = []
       Hybag::BulkIngester.new(dir).each do |ingester|
-        mime = FileMagic.new(FileMagic::MAGIC_MIME).file(ingester.bag.bag_files.first).split(';')[0]
+        @fail_ingest = 0
+        ingest_bag(ingester, assets)
+      end
+      assets
+    end
+
+    def ingest_bag(ingester, assets)
+      begin
+        sleep(2)
+        first_file = ingester.bag.bag_files.first
+        unless first_file.nil?
+          mime = FileMagic.new(FileMagic::MAGIC_MIME).file(ingester.bag.bag_files.first).split(';')[0]
+        end
 
         # Get class from mime pattern
         # TODO: extract this logic to GenericAsset (or elsewhere?)
@@ -13,16 +25,24 @@ module OregonDigital
           end
         end
 
+        puts "Ingesting #{ingester.bag.bag_dir}"
         ingester.model_name = klass ? klass.to_s : self.to_s
         asset = ingester.ingest
         update_rdf_subject(asset)
         asset.content.mimeType = mime
         # Overwrite existing format with the actual content format
-        asset.format = ::RDF::URI("http://purl.org/NET/mediatypes/#{asset.content.mimeType}")
+        asset.format = ::RDF::URI("http://purl.org/NET/mediatypes/#{asset.content.mimeType}") if mime
         asset.save
-        assets << asset
+      rescue Rubydora::FedoraInvalidRequest
+        @fail_ingest += 1
+        if @fail_ingest >= 3
+          raise "Failed to ingest asset 3 times."
+          return
+        end
+        puts "Failed to ingest asset #{@fail_ingest} times. Retrying."
+        ingest_bag(Hybag::Ingester.new(BagIt::Bag.new(ingester.bag.bag_dir)), assets)
       end
-      assets
+      assets << asset
     end
 
     private


### PR DESCRIPTION
Add reviewer facet route.

Retries were necessary in order to get bulk bags to ingest.
