### PR TITLE
Hide rspec deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ DUMMY_PATH = File.join(ROOT_PATH,"dummies")
 WebMock.disable_net_connect!(:allow_localhost => true)
 
 RSpec.configure do |config|
+  # Let Rails do its thing with spec types
+  config.infer_spec_type_from_file_location!
+
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:

--- a/spec/support/resque_inline.rb
+++ b/spec/support/resque_inline.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |example|
     Resque.inline = (example.metadata[:resque] == true)
   end
 end


### PR DESCRIPTION
Removes rspec's gargantuan deprecation warning blocks.

They annoyed me while testing and re-testing other work, so... any concerns with this hack?