### PR TITLE
Refactor Soft Delete Specs

### DIFF
--- a/app/controllers/destroyed_controller.rb
+++ b/app/controllers/destroyed_controller.rb
@@ -12,13 +12,16 @@ class DestroyedController < CatalogController
   end
 
   def undelete
-    asset = GenericAsset.find(params[:id])
     asset.undelete!
-    flash[:notice] = "Successfully restored object."
+    flash[:notice] = I18n.t('oregondigital.destroyed.undelete.success')
     redirect_to catalog_path(asset) 
   end
 
   private
+
+  def asset
+    @asset ||= GenericAsset.find(params[:id])
+  end
 
   def require_destroyed_items(solr_parameters, user_parameters)
     solr_parameters[:fq] ||= []
@@ -33,7 +36,7 @@ class DestroyedController < CatalogController
 
   def restrict_to_destroyers
     unless can? :destroy, GenericAsset
-      raise Hydra::AccessDenied.new "You do not have permission to manage destroyed objects."
+      raise Hydra::AccessDenied.new I18n.t('oregondigital.destroyed.unauthorized')
     end
   end
 end

--- a/app/controllers/generic_asset_controller.rb
+++ b/app/controllers/generic_asset_controller.rb
@@ -13,7 +13,7 @@ class GenericAssetController < ApplicationController
   def destroy
     authorize! :destroy, @generic_asset
     @generic_asset.soft_destroy
-    flash[:notice] = "Successfully deleted asset."
+    flash[:notice] = I18n.t("oregondigital.generic_asset.destroy")
     redirect_to catalog_path
   end
 

--- a/config/locales/oregondigital.en.yml
+++ b/config/locales/oregondigital.en.yml
@@ -1,5 +1,9 @@
 en:
   oregondigital:
+    destroyed:
+      unauthorized: You do not have permission to manage destroyed objects.
+      undelete:
+        success: Successfully restored object.
     generic_asset:
       destroy: Successfully deleted asset.
     metadata:

--- a/config/locales/oregondigital.en.yml
+++ b/config/locales/oregondigital.en.yml
@@ -1,5 +1,7 @@
 en:
   oregondigital:
+    generic_asset:
+      destroy: Successfully deleted asset.
     metadata:
       title: Title
       lcsubject: LC Subject

--- a/spec/controllers/destroyed_controller_spec.rb
+++ b/spec/controllers/destroyed_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe DestroyedController do
+  let(:user) {}
+  let(:core_asset) { FactoryGirl.build(:generic_asset) }
+  # I do this a lot. Can there be a "stubbed factory" or something?
+  let(:asset) do
+    core_asset.stub(:pid).and_return("oregondigital:bla")
+    core_asset.stub(:persisted?).and_return(true)
+    core_asset.stub(:save)
+    core_asset
+  end
+  before do
+    controller.stub(:asset).and_return(asset)
+    sign_in user if user
+  end
+
+  describe "GET undelete" do
+    def undelete_asset
+      get :undelete, :id => asset.pid
+    end
+    context "when logged in as a user" do
+      it "should be unauthorized" do
+        undelete_asset
+        expect(flash[:alert]).to eq I18n.t('oregondigital.destroyed.unauthorized') 
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+    context "when logged in as an admin" do
+      let(:user) { FactoryGirl.create(:admin) }
+      it "should call undelete! on asset" do
+        expect(asset).to receive(:undelete!)
+        undelete_asset
+      end
+      it "should set flash message" do
+        undelete_asset
+        expect(flash[:notice]).to eq I18n.t('oregondigital.destroyed.undelete.success')
+      end
+    end
+  end
+end

--- a/spec/controllers/generic_asset_controller_spec.rb
+++ b/spec/controllers/generic_asset_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe GenericAssetController do
+  let(:core_asset) { FactoryGirl.create(:generic_asset) }
+  let(:asset) do
+    core_asset.stub(:pid).and_return("oregondigital:bla")
+    core_asset
+  end
+  describe 'DELETE destroy' do
+    before do
+      sign_in user if user
+      controller.instance_variable_set(:@generic_asset, asset)
+    end
+    def delete_asset
+      delete :destroy, :id => asset.pid
+    end
+    context "when given a generic asset" do
+      let(:user) {}
+      context "when logged in as a user" do
+        it "should be unauthorized" do
+          expect{delete_asset}.to raise_error(CanCan::AccessDenied)
+        end
+      end
+      context "when logged in as an admin" do
+        let(:user) { FactoryGirl.create(:admin) }
+        it "should be authorized" do
+          expect{delete_asset}.not_to raise_error
+        end
+        it "should call soft_destroy" do
+          expect(asset).to receive(:soft_destroy)
+          delete_asset
+          expect(flash[:notice]).to eq I18n.t("oregondigital.generic_asset.destroy")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/soft_delete_spec.rb
+++ b/spec/features/soft_delete_spec.rb
@@ -10,23 +10,9 @@ describe 'soft delete' do
   end
   context "when a user is an admin" do
     let(:user) {FactoryGirl.create(:admin)}
-    context "and the item is already destroyed" do
-      before do
-        asset.soft_destroy
-        visit catalog_path(:id => asset.pid)
-      end
-      it "should have a working Undelete button" do
-        click_link "Undelete"
-        expect(page).to have_content("restored")
-        expect(asset.reload).not_to be_soft_destroyed
-      end
-    end
     context "and the destroy button is clicked" do
       before do
         click_link "Delete"
-        within("#main-flashes") do
-          expect(page).to have_content("Successfully deleted asset.")
-        end
       end
       it "should not show the asset on search results" do
         visit root_path(:search_field => "all_fields")

--- a/spec/features/soft_delete_spec.rb
+++ b/spec/features/soft_delete_spec.rb
@@ -10,9 +10,6 @@ describe 'soft delete' do
   end
   context "when a user is an admin" do
     let(:user) {FactoryGirl.create(:admin)}
-    it "should show a destroy button" do
-      expect(page).to have_link("Delete")
-    end
     context "and the item is already destroyed" do
       before do
         asset.soft_destroy
@@ -30,9 +27,6 @@ describe 'soft delete' do
         within("#main-flashes") do
           expect(page).to have_content("Successfully deleted asset.")
         end
-      end
-      it "should not really delete the asset" do
-        expect(Image.find(asset.pid).pid).to eq asset.pid
       end
       it "should not show the asset on search results" do
         visit root_path(:search_field => "all_fields")

--- a/spec/features/soft_delete_spec.rb
+++ b/spec/features/soft_delete_spec.rb
@@ -47,15 +47,6 @@ describe 'soft delete' do
     it "should not show a destroy button" do
       expect(page).not_to have_link("Delete")
     end
-    context "and there is a soft destroyed item" do
-      before do
-        asset.soft_destroy
-        visit catalog_path(:id => asset.pid)
-      end
-      it "should not let them see it" do
-        expect(page).to have_content("You do not have sufficient")
-      end
-    end
   end
 end
 

--- a/spec/features/soft_delete_spec.rb
+++ b/spec/features/soft_delete_spec.rb
@@ -18,9 +18,6 @@ describe 'soft delete' do
         asset.soft_destroy
         visit catalog_path(:id => asset.pid)
       end
-      it "should not show a destroy button" do
-        expect(page).not_to have_link("Delete")
-      end
       it "should have a working Undelete button" do
         click_link "Undelete"
         expect(page).to have_content("restored")
@@ -41,11 +38,6 @@ describe 'soft delete' do
         visit root_path(:search_field => "all_fields")
         expect(page).not_to have_selector(".document")
       end
-    end
-  end
-  context "when a user is not an admin" do
-    it "should not show a destroy button" do
-      expect(page).not_to have_link("Delete")
     end
   end
 end

--- a/spec/lib/oregon_digital/soft_destroy_spec.rb
+++ b/spec/lib/oregon_digital/soft_destroy_spec.rb
@@ -25,4 +25,15 @@ describe "#soft_destroy" do
       expect(asset).not_to be_soft_destroyed
     end
   end
+
+  describe "#undelete!" do
+    it "should call undelete" do
+      expect(asset).to receive(:undelete)
+      asset.undelete!
+    end
+    it "should call save" do
+      expect(asset).to receive(:save)
+      asset.undelete!
+    end
+  end
 end

--- a/spec/lib/oregon_digital/soft_destroy_spec.rb
+++ b/spec/lib/oregon_digital/soft_destroy_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "#soft_destroy" do
+  let(:asset) { FactoryGirl.build(:generic_asset) }
+  before do
+    asset.stub(:save)
+    asset.soft_destroy
+  end
+  it "should set #soft_destroyed?" do
+    expect(asset).to be_soft_destroyed
+  end
+  it "should reset workflow" do
+    expect(asset).to receive(:reset_workflow)
+    asset.soft_destroy
+  end
+
+  describe "#undelete" do
+    it "should not alter groups" do
+      before_groups = asset.read_groups
+      asset.undelete
+      expect(asset.read_groups).to eq before_groups
+    end
+    it "should no longer be destroyed" do
+      asset.undelete
+      expect(asset).not_to be_soft_destroyed
+    end
+  end
+end

--- a/spec/views/soft_delete_button_spec.rb
+++ b/spec/views/soft_delete_button_spec.rb
@@ -14,7 +14,7 @@ describe "catalog/_admin_show_tools.html.erb" do
     context "when the object is not soft deleted" do
       it "should have a soft destroy link" do
         render "catalog/admin_show_tools.html.erb", :decorated_object => decorated_object, :id => "bla"
-        expect(rendered).to have_link "Delete"
+        expect(rendered).to have_css "a[data-method='delete'][href='#{generic_asset_path(:id => asset.pid)}']", :text => "Delete"
       end
     end
     context "and the object is soft deleted" do
@@ -23,7 +23,7 @@ describe "catalog/_admin_show_tools.html.erb" do
       end
       it "should have an undelete link" do
         render "catalog/admin_show_tools.html.erb", :decorated_object => decorated_object, :id => "bla"
-        expect(rendered).to have_link "Undelete"
+        expect(rendered).to have_link "Undelete", :href => undelete_destroyed_path(asset.pid)
       end
     end
   end

--- a/spec/views/soft_delete_button_spec.rb
+++ b/spec/views/soft_delete_button_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe "catalog/_admin_show_tools.html.erb" do
+  let(:asset) { FactoryGirl.build(:generic_asset) }
+  let(:decorated_object) { asset.decorate }
+  let(:stub_permissions) {}
+  before do
+    stub_permissions
+    asset.stub(:pid).and_return("oregondigital:bla")
+    asset.stub(:persisted?).and_return(true)
+  end
+  context "when the user is an admin" do
+    let(:stub_permissions) { controller.stub(:can?).and_return(true) }
+    context "when the object is not soft deleted" do
+      it "should have a soft destroy link" do
+        render "catalog/admin_show_tools.html.erb", :decorated_object => decorated_object, :id => "bla"
+        expect(rendered).to have_link "Delete"
+      end
+    end
+    context "and the object is soft deleted" do
+      before do
+        asset.stub(:soft_destroyed?).and_return(true)
+      end
+      it "should have an undelete link" do
+        render "catalog/admin_show_tools.html.erb", :decorated_object => decorated_object, :id => "bla"
+        expect(rendered).to have_link "Undelete"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just for more discussion

This one was much harder. There's a few inline comments I want to make for discussion, but I'd also like input on what's left in https://github.com/OregonDigital/oregondigital/blob/feature/TrySoftDeleteSpecs/spec/features/soft_delete_spec.rb , which is primarily "display things that are queried". Any thoughts on how to pull that out? Or is this just the only way to avoid mucking about in Blacklight stuff?