### PR TITLE
Allow forced organization label

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/organization.rb
+++ b/lib/oregon_digital/controlled_vocabularies/organization.rb
@@ -3,6 +3,7 @@ module OregonDigital::ControlledVocabularies
     include OregonDigital::RDF::Controlled
     use_vocabulary :oregon_universities
     use_vocabulary :institutions
+    configure :rdf_label => RDF::SKOS.hiddenLabel
 
     property :label, :predicate => RDF::RDFS.label
   end


### PR DESCRIPTION
This lets us use the console to force a label if fetch is being wonky - as it's doing in dbpedia.