### PR TITLE
Disable fixing fedora index on fetch

### DIFF
--- a/app/jobs/fetch_all_job.rb
+++ b/app/jobs/fetch_all_job.rb
@@ -3,5 +3,6 @@ class FetchAllJob
   def self.perform(pid)
     object = ActiveFedora::Base.find(pid, :cast => true)
     object.descMetadata.fetch_external if object.descMetadata.respond_to?(:fetch_external)
+    object.update_index
   end
 end

--- a/lib/oregon_digital/rdf/deep_fetch.rb
+++ b/lib/oregon_digital/rdf/deep_fetch.rb
@@ -8,22 +8,7 @@ module OregonDigital::RDF
           next unless resource.kind_of?(ActiveFedora::Rdf::Resource)
           fetch_value(resource) if resource.kind_of? ActiveFedora::Rdf::Resource
           resource.persist! unless value.kind_of?(ActiveFedora::Base)
-          fix_fedora_index(property, resource)
         end
-      end
-    end
-
-    def fix_fedora_index(property, resource)
-      # Get assets which have this property set, but don't have the right label.
-      if resource.rdf_label.first.blank? || resource.rdf_label.first.to_s == resource.rdf_subject.to_s
-        assets = ActiveFedora::SolrService.query("#{Solrizer.solr_name(apply_prefix(property), :facetable)}:#{RSolr.escape(resource.rdf_subject.to_s)} AND #{Solrizer.solr_name(apply_prefix("#{property}_label"), :facetable)}:[\"\" TO *]", :rows => 1000000).map{|x| x["id"]}
-      else
-        assets = ActiveFedora::SolrService.query("#{Solrizer.solr_name(apply_prefix(property), :facetable)}:#{RSolr.escape(resource.rdf_subject.to_s)} AND -#{Solrizer.solr_name(apply_prefix("#{property}_label"), :facetable)}:#{RSolr.escape("#{resource.rdf_label.first}$#{resource.rdf_subject.to_s}")}", :rows => 1000000).map{|x| x["id"]}
-      end
-      assets.each do |a|
-        a = ActiveFedora::Base.find(a).adapt_to_cmodel
-        a.skip_queue = 1 if a.respond_to?(:skip_queue=)
-        a.update_index
       end
     end
 

--- a/spec/models/generic_asset_spec.rb
+++ b/spec/models/generic_asset_spec.rb
@@ -292,9 +292,6 @@ describe GenericAsset, :resque => true do
         expect(asset_2.descMetadata.lcsubject.first).not_to receive(:fetch)
         asset_2.descMetadata.fetch_external
       end
-      it "should persist the label to solr for other objects" do
-        expect(GenericAsset.where("desc_metadata__lcsubject_label_sim" => "Food industry and trade$#{subject_1.to_s}").length).to eq 1
-      end
     end
   end
 


### PR DESCRIPTION
Because of this, fetch jobs are taking hours per fetch, and there's thousands of fetch jobs, when a full reindex takes 6 hours.

This process is only useful if a label changes. My theory is that's pretty rare.