### PR TITLE
Don't index object for Mongo triples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'oai', :github => "code4lib/ruby-oai", :branch => :master
 # Old Asset Precompile Behavior for Stylesheets
 gem "sprockets-digest-assets-fix", :github => "tobiasr/sprockets-digest-assets-fix"
 
-gem 'rdf-mongo'
+gem 'rdf-mongo', :github => "terrellt/rdf-mongo"
 gem 'bson_ext'
 
 # Blacklight Advanced Search

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,14 @@ GIT
       rest-client
 
 GIT
+  remote: git://github.com/terrellt/rdf-mongo.git
+  revision: 4bd2a866fd9c8c4c65619c817325886ae70658e4
+  specs:
+    rdf-mongo (1.1.0)
+      mongo (>= 1.8.6)
+      rdf (>= 1.1)
+
+GIT
   remote: git://github.com/tobiasr/sprockets-digest-assets-fix.git
   revision: 88c756c20c17038fb5b463ae2430d13da35f33a8
   specs:
@@ -369,9 +377,6 @@ GEM
       nokogiri (~> 1.6)
       rdf (~> 1.1)
       rdf-xsd (~> 1.1)
-    rdf-mongo (1.1.0)
-      mongo (>= 1.8.6)
-      rdf (>= 1.1)
     rdf-n3 (1.1.0.1)
       rdf (~> 1.1)
     rdf-rdfa (1.1.3.1)
@@ -589,7 +594,7 @@ DEPENDENCIES
   qa!
   rails (~> 4.1.0)
   rdf (~> 1.1.2.1)
-  rdf-mongo
+  rdf-mongo!
   recursive-open-struct
   resque (~> 1.25.0)
   resque-retry


### PR DESCRIPTION
The previous Mongo implementation had an index built on Object, which exceeded the 1024 Byte limit for MongoDB document indexes. When this happened it broke the index for those subjects, and so not all items would get returned. Due to this we'd end up with RDF::Resources without full graphs which would then get persisted - hence no label.