### PR TITLE
Avoid Fedora session expiration by queueing single object reindexes.

### DIFF
--- a/app/jobs/reindex_everything_job.rb
+++ b/app/jobs/reindex_everything_job.rb
@@ -4,10 +4,7 @@ class ReindexEverythingJob
     ActiveFedora::Base.send(:connections).each do |conn|
       conn.search(nil) do |object|
         next if object.pid.start_with?('fedora-system:')
-        begin
-        ActiveFedora::Base.find(object.pid).update_index
-        rescue
-        end
+        Resque.enqueue(ReindexOneJob, object.pid)
       end
     end
   end

--- a/app/jobs/reindex_one_job.rb
+++ b/app/jobs/reindex_one_job.rb
@@ -1,0 +1,6 @@
+class ReindexOneJob
+  @queue = :reindex
+  def self.perform(pid)
+    ActiveFedora::Base.find(pid).update_index
+  end
+end


### PR DESCRIPTION
[ci skip]
