### PR TITLE
Re-fetch if no authoritative label

### DIFF
--- a/lib/oregon_digital/rdf/controlled.rb
+++ b/lib/oregon_digital/rdf/controlled.rb
@@ -66,7 +66,7 @@ module OregonDigital::RDF
     end
 
     def fetch
-      return unless rdf_label == [rdf_subject.to_s] || rdf_label.empty?
+      return unless rdf_label == [rdf_subject.to_s] || rdf_label.empty? || rdf_label.length > 1
       super
     end
 


### PR DESCRIPTION
This re-fetches if it can't find an authoritative label (likely if there's only non-english labels in the repository being used.)