### PR TITLE
Add middleware to strip */* from accept headers.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 
 Bundler.require(:default, Rails.env)
+require_relative '../lib/conneg_middleware'
 
 module Oregondigital
   class Application < Rails::Application
@@ -64,5 +65,6 @@ module Oregondigital
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+    config.middleware.use ::ConnegMiddleware
   end
 end

--- a/lib/conneg_middleware.rb
+++ b/lib/conneg_middleware.rb
@@ -1,0 +1,10 @@
+class ConnegMiddleware
+  def initialize(app)
+    @app = app
+  end
+ 
+  def call(env)
+    env["HTTP_ACCEPT"] = env["HTTP_ACCEPT"].to_s.gsub(/, ?\*\/\*(;q=.*)?$/,'')
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
Rails has a bug with priority in content negotiation and this is a hack to fix
it until it's fixed upstream. See https://github.com/rails/rails/issues/9940