### PR TITLE
Updating devise edit password url to use the real token

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>


### PR DESCRIPTION
From http://stackoverflow.com/questions/19018657/rails-4-devise-password-reset-is-always-giving-a-token-is-invalid-error-on

Fixes #868 

