### PR TITLE
Remove preferring hidden label.

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/organization.rb
+++ b/lib/oregon_digital/controlled_vocabularies/organization.rb
@@ -3,7 +3,6 @@ module OregonDigital::ControlledVocabularies
     include OregonDigital::RDF::Controlled
     use_vocabulary :oregon_universities
     use_vocabulary :institutions
-    configure :rdf_label => RDF::SKOS.hiddenLabel
 
     property :label, :predicate => RDF::RDFS.label
   end


### PR DESCRIPTION
This was making whatever was returned from typeahead the authoritative label.