### PR TITLE
Prevent double-click for review button and link

### DIFF
--- a/app/assets/javascripts/prevent-double-click.js.coffee
+++ b/app/assets/javascripts/prevent-double-click.js.coffee
@@ -1,0 +1,18 @@
+$ = jQuery
+
+$ ->
+  $(".prevent-double-click").each ->
+    $(this).prevent_double_click()
+
+$.fn.prevent_double_click = () ->
+  control = $(this)
+  control.click((event) ->
+    last_clicked = control.data("last-clicked")
+
+    if last_clicked && jQuery.now() - last_clicked < 8000
+      event.preventDefault()
+      event.stopPropagation()
+      return
+
+    control.data("last-clicked", jQuery.now())
+  )

--- a/app/views/catalog/_admin_show_tools.html.erb
+++ b/app/views/catalog/_admin_show_tools.html.erb
@@ -25,7 +25,8 @@
   <% end %>
   <% if can?(:review, decorated_object) && !decorated_object.reviewed? && !decorated_object.soft_destroyed? %>
     <li>
-      <%= link_to(review_generic_asset_path(decorated_object), :method => :put) do %>
+      <%= link_to(review_generic_asset_path(decorated_object),
+          :method => :put, :class => "prevent-double-click") do %>
         <span>Mark as Reviewed</span>
         <span class="sr-only"><%= decorated_object.title %></span>
       <% end %>

--- a/app/views/reviewer/_index_default.html.erb
+++ b/app/views/reviewer/_index_default.html.erb
@@ -1,3 +1,4 @@
-<%= button_to "Mark as Reviewed", review_generic_asset_path(document.id), :method => :put %>
+<%= button_to "Mark as Reviewed", review_generic_asset_path(document.id),
+    :method => :put, :class => "prevent-double-click" %>
 
 <%= render :partial => "catalog/index_default", :locals => local_assigns %>


### PR DESCRIPTION
Clicks have to be 8 seconds apart for them to be counted.  Ideally we'd
have a visual indicator that the control had been clicked, but
prevention is more important than making it nice right now.

closes #919 