### PR TITLE
Fix test output

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,8 @@ Oregondigital::Application.configure do
   config.action_controller.perform_caching = true
   config.cache_store = :mem_cache_store
 
+  Deprecation.default_deprecation_behavior = :silence
+
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,6 +14,8 @@ Oregondigital::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
+  Deprecation.default_deprecation_behavior = :silence
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,9 @@ DUMMY_PATH = File.join(ROOT_PATH,"dummies")
 WebMock.disable_net_connect!(:allow_localhost => true)
 
 RSpec.configure do |config|
+  # Let Rails do its thing with spec types
+  config.infer_spec_type_from_file_location!
+
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
 # Coverage
-require 'simplecov'
-
 unless ENV['NO_COVERAGE']
   require 'simplecov'
+  require 'coveralls'
 
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
       SimpleCov::Formatter::HTMLFormatter,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,19 @@
 # Coverage
 require 'simplecov'
-require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-]
-pid = Process.pid
-SimpleCov.at_exit do
-  SimpleCov.result.format! if Process.pid == pid
+unless ENV['NO_COVERAGE']
+  require 'simplecov'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+  ]
+  pid = Process.pid
+  SimpleCov.at_exit do
+    SimpleCov.result.format! if Process.pid == pid
+  end
+  SimpleCov.start('rails')
 end
-SimpleCov.start('rails')
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)

--- a/spec/support/resque_inline.rb
+++ b/spec/support/resque_inline.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |example|
     Resque.inline = (example.metadata[:resque] == true)
   end
 end


### PR DESCRIPTION
Removes multiple deprecation warnings (OD2 is a completely rewritten codebase, and OD1 won't be updating to the newest Hydra/Rails, so I see no value in these) and adds an option to skip coverage reporting when running tests.

Makes tests a bit faster, and output significantly more readable, especially when just trying to run a handful of tests.