### PR TITLE
cache cpd table

### DIFF
--- a/app/views/catalog/_compound.html.erb
+++ b/app/views/catalog/_compound.html.erb
@@ -1,6 +1,6 @@
 </div>
 <div class="well" id="contents">
-
+<% cache "cpd/#{decorated_object.pid}", skip_digest: true do %>
 <ul class="nav nav-list">
     <li class="nav-header">Contents</li>
       <% decorated_object.compound_list.each do |item| %>
@@ -8,4 +8,4 @@
       <% end %>
     </li>
 </ul>
-
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,9 +16,9 @@ Oregondigital::Application.configure do
 
   Deprecation.default_deprecation_behavior = :silence
 
-  # Show full error reports and disable caching
+  # Show full error reports and enable caching
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false

--- a/spec/features/compound_object_spec.rb
+++ b/spec/features/compound_object_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include ActionController::Caching::Fragments
 
 describe "compound objects" do
   let(:parent) {FactoryGirl.create(:generic_asset)}
@@ -79,6 +80,7 @@ describe "compound objects" do
     end
     context "and the page is visited" do
       before do
+        Rails.cache.clear
         visit catalog_path(object.pid)
       end
       context "and the parent is an image" do
@@ -91,6 +93,16 @@ describe "compound objects" do
       it "should show a table of contents" do
         expect(page).to have_content("Contents")
         expect(page).to have_content(object_2.title)
+      end
+      it "should cache the table of contents fragment" do
+        Rails.cache.read(fragment_cache_key("cpd/" + object.pid)).should have_content(object.title)
+      end
+      context "but when the parent is saved" do
+        let (:parent) {FactoryGirl.create(:image) }
+        it "should not be in cache" do
+          parent.save
+          Rails.cache.read(fragment_cache_key("cpd/" + object.pid)).should be_nil
+        end
       end
       it "should not have a link to the current item" do
         expect(page).not_to have_link(object.title)


### PR DESCRIPTION
fixes #1007 
So this expires the cache of each member if a child or parent is saved. does not yet address the issue of soft_destroy.