### PR TITLE
Set up docker for development and testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+set_content
+jetty

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
 gem 'blacklight'
-gem 'hydra-head', '6.4.0', :git => 'https://github.com/no-reply/hydra-head.git', :branch => 'AF7-RDF'
-gem 'active-fedora', :git => 'https://github.com/no-reply/active_fedora.git', :branch => 'oregon-af7'
+gem 'hydra-head', '6.4.0', :git => 'https://github.com/OregonDigital/hydra-head'
+gem 'active-fedora', :git => 'https://github.com/OregonDigital/active_fedora'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,9 +44,8 @@ GIT
     sprockets-digest-assets-fix (1.0.0)
 
 GIT
-  remote: https://github.com/no-reply/active_fedora.git
-  revision: 3ee384fd3e3fcd83b226bf2840ad23788f157b11
-  branch: oregon-af7
+  remote: https://github.com/OregonDigital/active_fedora
+  revision: 78cf58e6028b72ea3848d1e0567697283a17ad0c
   specs:
     active-fedora (7.0.0.rc3)
       activesupport (>= 3.0.0)
@@ -60,9 +59,8 @@ GIT
       rubydora (~> 1.7.4)
 
 GIT
-  remote: https://github.com/no-reply/hydra-head.git
-  revision: bca8881b54af81dae02b659036481474089834e1
-  branch: AF7-RDF
+  remote: https://github.com/OregonDigital/hydra-head
+  revision: 1ab00dd5c574c99852acb3a44486c6a5f706ca45
   specs:
     hydra-access-controls (6.4.0)
       active-fedora
@@ -268,7 +266,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (4.2.0)
       railties (>= 3.2.16)
-    json (1.8.1)
+    json (1.8.3)
     json-ld (1.1.4)
       rdf (~> 1.1)
     kaminari (0.14.1)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,77 @@ Connected projects:
 Local Development Setup
 -----
 
+### Using Docker
+
+Pull images from dockerhub to speed the setup - phantomjs in particular takes a
+LONG time to build:
+
+```bash
+docker pull oregondigital/od1
+docker pull oregondigital/od1-test
+docker pull oregondigital/solr
+docker pull oregondigital/phantomjs
+docker pull oregondigital/hydra-jetty:3.8.1-4.0
+```
+
+```bash
+# Grab the repository
+git clone git@github.com:OregonDigital/oregondigital.git
+
+# Run the dev stack with docker-compose, nicely wrapped in a shell script
+./docker/compose up
+
+# You can run compose manually, as well, just MAKE SURE YOU PICK A CONSISTENT
+# PROJECT NAME!  It must be different from your test setup!  Don't go with the
+# default project name!  If you do that for dev and test, you'll end up with
+# container name collisions, which could ruin your dev data!  (Or use the
+# default name here, but make sure you never use it for testing)
+docker-compose -p OD1 up
+
+# Set up the database
+docker-compose -p OD1 exec web bundle exec rake db:migrate
+docker-compose -p OD1 exec web bundle exec rake admin_user
+
+# If you do the above while the containers are not running, use the "run"
+# subcommand instead of the "exec" subcommand, but be warned that leaves trash
+# containers lying around until you clean up.
+docker-compose -p OD1 run web bundle exec rake db:migrate
+docker-compose -p OD1 run web bundle exec rake admin_user
+
+# When you change code, rebuild the od container
+docker-compose -p OD1 rm web
+docker-compose -p OD1 build web
+docker-compose -p OD1 up
+
+# Alternatively, run dev.sh to do some extra setup such as rebuilding the OD1 image and running migrations:
+./docker/dev.sh
+```
+
+You can run commands against the web head via standard compose commands using
+the wrapper.  e.g., `./docker/compose exec web bundle exec rake admin_user`.
+
+#### Testing
+
+Easy as `./docker/test.sh`!  Except....
+
+In order to test, you need `phantombin/phantomjs`.  This can be built and
+copied automatically for you:
+
+    docker pull oregondigital/phantomjs
+    docker-compose -p ODTEST -f test-compose.yaml run phantomjs
+
+**BUT**: it's a VERY slow process.  If you can find a 1.8.1 binary that works
+in Ubuntu 12.04, you'll be a lot better off.  Once the binary is in
+`phantombin/phantomjs`, you should be fine moving forward.
+
+Other information:
+
+- Want to focus tests?  Just pass in a path: `./docker/test.sh spec/models`.
+- If you need to ensure your environment is pristine, use the `--destroy` flag,
+  which will destroy and rebuild all containers.
+
+### Manual
+
 **Requires Ruby 2.0**
 
     git clone git@github.com:OregonDigital/oregondigital.git
@@ -38,8 +109,8 @@ ln -s /path/to/rails/media/thumbnails public/thumbnails
 
 Install memcached if needed, or make sure it's running (needed for login sessions):
 
-* Ubuntu: ```sudo apt-get install memcached```
-* Mac/Homebrew: ```brew install memcached```
+* Ubuntu: `sudo apt-get install memcached`
+* Mac/Homebrew: `brew install memcached`
 * Other: http://memcached.org/downloads
 
 Start the servers:
@@ -47,8 +118,7 @@ Start the servers:
     rake jetty:start
 	rails server
 
-Vagrant Setup
------
+### Vagrant Setup
 
 Requires [Git](http://www.git-scm.com/),
 [VirtualBox](https://www.virtualbox.org/), and

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module Oregondigital
     # Activate observers that should always be running.
     # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
 
+    config.cache_store = :mem_cache_store, *((ENV['MEMCACHE_SERVERS'] || "localhost:11211").split(",").map(&:strip))
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,6 @@ Oregondigital::Application.configure do
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
-  config.cache_store = :mem_cache_store
 
   Deprecation.default_deprecation_behavior = :silence
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,6 @@ Oregondigital::Application.configure do
   Syslog::Logger.syslog = Syslog.open("rails-oregondigital-prod", nil, Syslog::LOG_LOCAL0)
   config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new)
 
-  # Use a different cache store in production
-  config.cache_store = :mem_cache_store, *((ENV['MEMCACHE_SERVERS'] || "localhost:11211").split(",").map(&:strip))
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,9 +43,6 @@ Oregondigital::Application.configure do
   # Use a different logger for distributed setups
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production
-  config.cache_store = :mem_cache_store
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,11 +1,11 @@
 development:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora
+  user: <%= ENV['OREGONDIGITAL_FEDORA_USER'] || "fedoraAdmin" %>
+  password: <%= ENV['OREGONDIGITAL_FEDORA_PASSWORD'] || "fedoraAdmin" %>
+  url: <%= ENV['OREGONDIGITAL_FEDORA_HOST'] || "http://127.0.0.1:8983/fedora" %>
 test: &TEST
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/fedora-test" %>
+  user: <%= ENV['OREGONDIGITAL_FEDORA_USER'] || "fedoraAdmin" %>
+  password: <%= ENV['OREGONDIGITAL_FEDORA_PASSWORD'] || "fedoraAdmin" %>
+  url: <%= ENV['OREGONDIGITAL_FEDORA_HOST'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/fedora-test" %>
 production:
   user: <%= ENV['OREGONDIGITAL_FEDORA_USER'] || "fedoraAdmin" %>
   password: <%= ENV['OREGONDIGITAL_FEDORA_PASSWORD'] || "fedoraAdmin" %>

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,2 @@
+$redis = Redis.new(:host => ENV["REDIS_HOST"] || "localhost", :port => ENV["REDIS_PORT"] || 6379)
+Resque.redis = $redis

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,9 +1,9 @@
 # This is a sample config file that does not have multiple solr instances. You will also need to be sure to
 # edit the fedora.yml file to match the solr URL for active-fedora.
 development:
-  url: http://localhost:8983/solr/development
+  url: <%= ENV['OREGONDIGITAL_SOLR_HOST'] || "http://localhost:8983/solr/development" %>
 test: &TEST
-  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>
+  url: <%= ENV['OREGONDIGITAL_SOLR_HOST'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>
 cucumber:
   <<: *TEST
 production:

--- a/doc/README_FOR_APP
+++ b/doc/README_FOR_APP
@@ -1,2 +1,0 @@
-Use this README file to introduce your application and point to useful places in the API for learning more.
-Run "rake doc:app" to generate API documentation for your models, controllers, helpers, and libraries.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,93 @@
+version: '2'
+services:
+  # Back-end services
+  memcached:
+    image: memcached
+  mongo:
+    image: mongo
+    volumes:
+      - data-mongo:/data/db
+  redis:
+    image: redis
+    command: redis-server --appendonly yes
+    volumes:
+      - data-redis:/data
+  solr:
+    image: oregondigital/solr
+    build:
+      dockerfile: docker/Dockerfile-solr
+      context: .
+    ports:
+      - "8983:8983"
+    volumes:
+      - data-solr-dev:/opt/solr/server/solr/mycores
+  fc381:
+    image: oregondigital/hydra-jetty:3.8.1-4.0
+    build:
+      dockerfile: docker/Dockerfile-hydra-jetty
+      context: .
+    command: bash -c "rm -f /opt/jetty/webapps/solr.war && java -jar start.jar"
+    ports:
+      - "8984:8983"
+    volumes:
+      - data-fedora:/opt/jetty/fedora/default/data
+      - data-derby:/opt/jetty/fedora/default/derby
+      - ./media:/oregondigital/media
+  workers:
+    image: oregondigital/od1
+    build:
+      dockerfile: docker/Dockerfile-dev
+      context: .
+    volumes:
+      - ./db:/oregondigital/db/
+      - ./media:/oregondigital/media
+    command: bundle exec rake resque:work
+    links:
+      - memcached
+      - redis
+      - mongo
+      - solr
+      - fc381
+    env_file:
+      - docker/web-variables.env
+      - docker/resque-variables.env
+
+  # Front-end stuff
+  web:
+    image: oregondigital/od1
+    build:
+      dockerfile: docker/Dockerfile-dev
+      context: .
+    volumes:
+      - ./db:/oregondigital/db/
+      - ./media:/oregondigital/media
+    command: bash -c "rm -f /oregondigital/tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"
+    ports:
+      - "3000:3000"
+    links:
+      - memcached
+      - redis
+      - mongo
+      - solr
+      - fc381
+    env_file:
+      - docker/web-variables.env
+  resquehead:
+    image: oregondigital/od1
+    build:
+      dockerfile: docker/Dockerfile-dev
+      context: .
+    command: bundle exec resque-web -FL -r redis:6379
+    ports:
+      - "5678:5678"
+    links:
+      - redis
+    env_file:
+      - docker/web-variables.env
+      - docker/resque-variables.env
+volumes:
+  data-mongo: {}
+  data-solr-dev: {}
+  data-fedora: {}
+  data-derby: {}
+  data-redis: {}

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,0 +1,134 @@
+# Creates an image suitable for running the Rails stack for OD 1.  This is for
+# development at the moment; production Dockerizing will need tweaking to get
+# all the code baked into an image, possibly set up safer settings, etc.
+#
+# Build:
+#     docker build --rm -t oregondigital/od1 -f docker/Dockerfile-dev .
+
+# TODO: Upgrade ubuntu!  Right now this just needs to work with what we have in
+# circleci, but longer-term this could get problematic when ubuntu 12 hits EOL.
+#
+# Known issues:
+# - VIPS install will need to be figured out for a newer Ubuntu
+# - Will need to test derivative generation for all types since CLI changes sometimes happen
+# - ffmpeg will need to be replaced, and libavcode-extra-53 definitely has to be replaced
+FROM ubuntu:12.04
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+
+# apt won't find some libs if this isn't run
+RUN apt-get update
+
+# Dependencies for vips installer
+RUN apt-get install -y pkg-config
+RUN apt-get install -y python-software-properties software-properties-common
+
+# Vips!  This is very specific to Ubuntu 12.04, pulled out of vips-install.sh
+RUN add-apt-repository -y ppa:lyrasis/precise-backports
+RUN apt-get install -y automake build-essential gobject-introspection gtk-doc-tools libglib2.0-dev \
+                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff4-dev libexif-dev \
+                       libgsf-1-dev liblcms2-dev libxml2-dev swig libmagickcore-dev curl
+RUN mkdir -p /opt/libvips
+WORKDIR /opt/libvips
+RUN curl http://www.vips.ecs.soton.ac.uk/supported/7.42/vips-7.42.3.tar.gz | tar zx
+WORKDIR /opt/libvips/vips-7.42.3
+RUN ./configure --enable-debug=no --enable-docs=no --enable-cxx=yes --without-python --without-orc --without-fftw
+RUN make
+RUN make install
+RUN ldconfig
+
+# Various derivative libs
+RUN apt-get purge libreoffice*
+RUN add-apt-repository -y ppa:libreoffice/ppa
+RUN apt-get install -y poppler-utils poppler-data ghostscript libreoffice
+RUN apt-get install -y libmagic-dev libmagickwand-dev ffmpeg libvorbis-dev libavcodec-extra-53
+RUN apt-get install -y graphicsmagick
+
+# Database connection libraries
+RUN apt-get install -y libmysqlclient-dev
+RUN apt-get install -y libsqlite3-dev
+
+# Nodejs for compiling assets
+RUN apt-get install -y nodejs
+
+# We need git for all our github-hosted gems
+RUN apt-get install -y git
+
+# Dependencies for Ruby
+RUN apt-get install -y libssl-dev libreadline-dev
+
+# Grab Ruby manually - can't install the default for Ubuntu 12.04
+#
+# Make sure this comes after the big downloads, as it's more likely we'll
+# change our ruby version than, say, our vips version - at least until we deal
+# with a major change (like OS) that would require a ruby rebuild anyway
+RUN mkdir -p /opt/ruby
+WORKDIR /opt/ruby
+RUN curl https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz | tar zx
+WORKDIR /opt/ruby/ruby-2.2.5
+RUN ./configure
+RUN make
+RUN make install
+
+# Set an environment variable to store where the app is installed to inside
+# of the Docker image
+ENV INSTALL_PATH /oregondigital
+RUN mkdir -p $INSTALL_PATH
+WORKDIR $INSTALL_PATH
+
+# Grab bundler for installing the gems
+RUN gem install bundler
+
+# Grab the current gemfiles from github so we have a place to start with
+# bundler - this ensures that changes to Gemfile and Gemfile.lock don't re-pull
+# the entire list of gems
+RUN curl -O https://raw.githubusercontent.com/OregonDigital/oregondigital/master/Gemfile
+RUN curl -O https://raw.githubusercontent.com/OregonDigital/oregondigital/master/Gemfile.lock
+RUN bundle install
+
+# Pull down set content
+COPY docker/sync-sets.sh /sync-sets.sh
+RUN chmod +x /sync-sets.sh
+RUN /sync-sets.sh
+
+# Create symlinks
+COPY docker/link-set-content.sh /link-set-content.sh
+RUN chmod +x /link-set-content.sh
+RUN /link-set-content.sh
+
+# Let's create the temp dirs manually instead of using rake, which depends on
+# the app already being in place
+RUN mkdir -p tmp/sessions tmp/sockets tmp/pids tmp/cache/assets/development \
+             tmp/cache/assets/test tmp/cache/assets/production
+
+# Copy in OD code one piece at a time so we can trust what we end up with
+COPY app app
+COPY config config
+COPY config.ru config.ru
+COPY db db
+COPY lib lib
+COPY public public
+COPY Rakefile Rakefile
+COPY script script
+COPY spec spec
+COPY test test
+COPY vendor vendor
+
+# Now add the Gemfiles and re-bundle - this is redundant, I know, but it makes
+# development better by only pulling changed gems and not re-running a bunch of
+# extraneous steps
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+RUN bundle install
+
+RUN mkdir -p /oregondigital/media/thumbnails
+RUN ln -s /oregondigital/media /oregondigital/public/media
+RUN ln -s /oregondigital/media/thumbnails /oregondigital/public/thumbnails
+
+# Expose a volume so that the web server can read assets
+VOLUME ["$INSTALL_PATH/public"]
+
+# Allow devs to override the app code entirely
+VOLUME ["$INSTALL_PATH/"]
+
+# The default command runs the web server
+CMD bundle exec rails s -p 3000 -b "0.0.0.0"

--- a/docker/Dockerfile-hydra-jetty
+++ b/docker/Dockerfile-hydra-jetty
@@ -1,0 +1,19 @@
+# Creates an image suitable for running hydra-jetty with Solr 4.0 and Fedora
+# Commons 3.8.1.  This is pretty dev-centric and may not be suitable for
+# a production environment.
+#
+# Build:
+#     docker build --rm -t oregondigital/hydra-jetty -f docker/Dockerfile-hydra-jetty .
+FROM openjdk:8
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+
+RUN apt-get update
+RUN apt-get install -y git
+
+# Grab the project we set up for OD to use Fedora 3.8.1 - this is a shallow
+# clone so it won't be a 1-2 gig download, but it's still pretty big.
+RUN git clone https://github.com/OregonDigital/hydra-jetty-fedora381.git /opt/jetty
+WORKDIR /opt/jetty
+
+# Default to starting the service
+CMD java -Djetty.port=8983 -Dsolr.solr.home=/oregondigital/jetty/solr -XX:MaxPermSize=128m -Xmx256m -jar start.jar

--- a/docker/Dockerfile-phantomjs
+++ b/docker/Dockerfile-phantomjs
@@ -1,0 +1,22 @@
+# Creates an image containing phantomjs 1.8.1 for the OD setup
+#
+# Build:
+#     docker build --rm -t oregondigital/phantomjs -f docker/Dockerfile-phantomjs .
+
+# TODO: Upgrade ubuntu when the dev setup upgrades!
+FROM ubuntu:12.04
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+
+# apt won't find some libs if this isn't run
+RUN apt-get update
+
+# PhantomJS dependencies
+RUN apt-get install -y build-essential g++ flex bison gperf ruby perl \
+  libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-dev \
+  libpng-dev libjpeg-dev python libx11-dev libxext-dev
+
+RUN apt-get install -y git
+RUN git clone https://github.com/ariya/phantomjs/ /opt/phantomjs
+WORKDIR /opt/phantomjs
+RUN git checkout 1.8.1
+RUN yes | ./build.sh

--- a/docker/Dockerfile-solr
+++ b/docker/Dockerfile-solr
@@ -1,0 +1,8 @@
+# Creates an image suitable for running Solr in a way that works with OD 1
+#
+# Build:
+#     docker build --rm -t oregondigital/solr -f docker/Dockerfile-solr .
+FROM solr:6-alpine
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+COPY solr_conf/conf_v6 /var/odconf
+COPY docker/solrsetup.sh /docker-entrypoint-initdb.d/odsetup.sh

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -1,0 +1,6 @@
+# Creates an image suitable for running the OD 1 tests
+FROM oregondigital/od1
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+
+# If you don't have a phantomJS binary, version 1.8.1, you need to run the phantomjs container to build it
+COPY ./phantombin/phantomjs /usr/bin/phantomjs

--- a/docker/compose
+++ b/docker/compose
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#
+# Simple wrapper around the docker-compose call with some sane pre-defined stuff
+docker-compose -p OD1 $@

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# This script is primarily just for demonstrating what needs to happen to get
+# set up.  Some things may need to be tweaked, such as only migrating once.
+# Feel free to copy this to create your own docker-compose adventure!
+
+# Stop everything
+./docker/compose stop
+
+# Build, migrate, and clean up
+docker build --rm -t oregondigital/od1 -f docker/Dockerfile-dev .
+./docker/compose run web bundle exec rake db:migrate
+./docker/compose rm -f web
+./docker/compose rm -f workers
+./docker/compose rm -f resquehead
+
+# Restart
+./docker/compose up

--- a/docker/link-set-content.sh
+++ b/docker/link-set-content.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Creates symlinks to set content for views and assets
+PATH=/oregondigital
+REPO_PATH="$PATH/set_content"
+GITFILE="$REPO_PATH/.git"
+ASSET_PATH="$PATH/app/assets"
+SET_JS_PATH="$ASSET_PATH/javascripts/sets"
+SET_IMG_PATH="$ASSET_PATH/images/sets"
+SET_CSS_PATH="$ASSET_PATH/stylesheets/sets"
+SET_CONTENT_PATH="$PATH/app/views/sets"
+
+/bin/mkdir -p $SET_JS_PATH
+/bin/mkdir -p $SET_CSS_PATH
+/bin/mkdir -p $SET_IMG_PATH
+/bin/mkdir -p $SET_CONTENT_PATH
+
+remove_symlinks() {
+  /usr/bin/find $SET_JS_PATH -type l -exec rm {} \;
+  /usr/bin/find $SET_CSS_PATH -type l -exec rm {} \;
+  /usr/bin/find $SET_IMG_PATH -type l -exec rm {} \;
+  /usr/bin/find $SET_CONTENT_PATH -type l -exec rm {} \;
+}
+
+create_symlinks() {
+  for setdir in $(/usr/bin/find $REPO_PATH -maxdepth 1 -type d -not -name ".*"); do
+    setname=${setdir##*/}
+
+    dir=$setdir/content
+    if [[ -d $dir ]]; then
+      /bin/ln -s $dir $SET_CONTENT_PATH/$setname
+    fi
+
+    dir=$setdir/assets/javascripts
+    if [[ -d $dir ]]; then
+      /bin/ln -s $dir $SET_JS_PATH/$setname
+    fi
+
+    dir=$setdir/assets/images
+    if [[ -d $dir ]]; then
+      /bin/ln -s $dir $SET_IMG_PATH/$setname
+    fi
+
+    dir=$setdir/assets/stylesheets
+    if [[ -d $dir ]]; then
+      /bin/ln -s $dir $SET_CSS_PATH/$setname
+    fi
+  done
+}
+
+remove_symlinks
+create_symlinks

--- a/docker/resque-variables.env
+++ b/docker/resque-variables.env
@@ -1,0 +1,2 @@
+COUNT=3
+QUEUE=*

--- a/docker/solrsetup.sh
+++ b/docker/solrsetup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Modified from solr-precreate task in distribution's script
+CORE=development
+CONFIG_SOURCE="/opt/solr/server/solr/configsets/data_driven_schema_configs"
+coresdir="/opt/solr/server/solr/mycores"
+mkdir -p $coresdir
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+
+# Override stuff with OD files
+rm -f $coredir/conf/managed-schema
+cp /var/odconf/schema.xml $coredir/conf/schema.xml
+cp /var/odconf/solrconfig.xml $coredir/conf/solrconfig.xml

--- a/docker/sync-sets.sh
+++ b/docker/sync-sets.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Syncs data from github for set content.  Meant to be run as part of an image
+# build; use the rake task to resync if necessary.
+PATH=/oregondigital
+REPO_PATH="$PATH/set_content"
+GITFILE="$REPO_PATH/.git"
+ASSET_PATH="$PATH/app/assets"
+SET_JS_PATH="$ASSET_PATH/javascripts/sets"
+SET_IMG_PATH="$ASSET_PATH/images/sets"
+SET_CSS_PATH="$ASSET_PATH/stylesheets/sets"
+SET_CONTENT_PATH="$PATH/app/views/sets"
+
+gitclone() {
+  /usr/bin/git clone https://github.com/OregonDigital/oregon-digital-set-content.git $REPO_PATH
+}
+
+if [[ ! -d $GITFILE ]]; then
+  gitclone
+fi

--- a/docker/test-variables.env
+++ b/docker/test-variables.env
@@ -1,0 +1,6 @@
+MONGODB_HOST=mongo
+RAILS_ENV=test
+OREGONDIGITAL_FEDORA_HOST=http://fc381:8983/fedora
+OREGONDIGITAL_SOLR_HOST=http://solr:8983/solr/development
+MEMCACHE_SERVERS=memcached:11211
+REDIS_HOST=redis

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Simplify testing with careful wrapping of test stuff
+
+# Need to debug?  Try this handy alias:
+#
+# alias dctest="docker-compose -p ODTEST -f test-compose.yaml"
+
+dctest() {
+  docker-compose -p ODTEST -f test-compose.yaml $@
+}
+
+# Rebuild the OD images just so we know it's good to go with whatever changes
+# we've made last
+dctest build od
+dctest build test
+
+# Test containers aren't important and can just be destroyed as needed
+if [[ $1 == "--destroy" ]]; then
+  dctest kill
+  dctest rm -f
+  shift
+fi
+
+# Start services one at a time so we can watch the actual test output properly.
+# We should probably reconsider using compose for testing, but meh....
+dctest create
+dctest start fc381
+dctest start memcached
+dctest start redis
+dctest start mongo
+dctest start solr
+
+# Fedora is the slow one, so we wait until we get a response
+echo "Waiting for Fedora to start"
+while true; do
+  curl -s http://127.0.0.1:18983 >/dev/null && break
+  sleep 0.1
+done
+
+target=${@:-spec/}
+# Run tests!
+echo "Running 'bundle exec rspec $target'"
+dctest run test bundle exec rspec $target

--- a/docker/web-variables.env
+++ b/docker/web-variables.env
@@ -1,0 +1,6 @@
+MONGODB_HOST=mongo
+RAILS_ENV=development
+OREGONDIGITAL_FEDORA_HOST=http://fc381:8983/fedora
+OREGONDIGITAL_SOLR_HOST=http://solr:8983/solr/development
+MEMCACHE_SERVERS=memcached:11211
+REDIS_HOST=redis

--- a/lib/oregon_digital/rdf/deep_fetch.rb
+++ b/lib/oregon_digital/rdf/deep_fetch.rb
@@ -37,7 +37,7 @@ module OregonDigital::RDF
     end
 
     def redis_connection
-      @redis ||= Redis.new
+      $redis
     end
   end
 end

--- a/phantombin/.gitignore
+++ b/phantombin/.gitignore
@@ -1,0 +1,3 @@
+*
+!.keep
+!.gitignore

--- a/solr_conf/conf_v6/schema.xml
+++ b/solr_conf/conf_v6/schema.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema name="Hydra" version="1.5">
+  <!-- NOTE: various comments and unused configuration possibilities have been purged
+     from this file.  Please refer to http://wiki.apache.org/solr/SchemaXml,
+     as well as the default schema file included with Solr -->
+  
+  <uniqueKey>id</uniqueKey>
+  
+  <fields>
+    <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
+    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+    
+    <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+    <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+
+    <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
+
+    <!-- text (_t...) -->
+    <dynamicField name="*_ti" type="text" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tim" type="text" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ts" type="text" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    
+    <!-- English text (_te...) -->
+    <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_tes" type="text_en" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_tesm" type="text_en" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_tesi" type="text_en" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tesim" type="text_en" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_teiv" type="text_en" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    
+    <!-- string (_s...) -->
+    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
+    
+    <!-- integer (_i...) -->
+    <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_is" type="int" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- trie integer (_it...) (for faster range queries) -->
+    <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_its" type="tint" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- date (_dt...) -->
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
+    <dynamicField name="*_dti" type="date" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtim" type="date" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dts" type="date" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- trie date (_dtt...) (for faster range queries) -->
+    <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dtts" type="tdate" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- long (_l...) -->
+    <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ls" type="long" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- trie long (_lt...) (for faster range queries) -->
+    <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_lts" type="tlong" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- double (_db...) -->
+    <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dbs" type="double" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- trie double (_dbt...) (for faster range queries) -->
+    <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dbts" type="tdouble" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- float (_f...) -->
+    <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_fs" type="float" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- trie float (_ft...) (for faster range queries) -->
+    <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_fts" type="tfloat" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
+    
+    <!-- boolean (_b...) -->
+    <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
+    
+    <!-- Type used to index the lat and lon components for the "location" FieldType -->
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
+
+    <!-- location (_ll...) -->
+    <dynamicField name="*_lli" type="location" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_llim" type="location" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_lls" type="location" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_llsm" type="location" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_llsim" type="location" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
+    <field name="all_text_timv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+
+
+  </fields>
+
+
+  <!-- Above, multiple source fields are copied to the [text] field.
+      Another way to map multiple source fields to the same
+      destination field is to use the dynamic field syntax.
+      copyField also supports a maxChars to copy setting.  -->
+
+    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+  <copyField source="*_tesim" dest="all_text_timv"/>
+  <copyField source="*_teim" dest="all_text_timv"/>
+  <copyField source="*_tsimv" dest="all_text_timv"/>
+  <types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
+    
+    <!-- Default numeric field types.  -->
+    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
+    
+    <!-- trie numeric field types for faster range queries -->
+    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
+    
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
+      -->
+    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <!-- A Trie based date field for faster date range queries and date faceting. -->
+    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    
+    
+    <!-- This point type indexes the coordinates as separate fields (subFields)
+      If subFieldType is defined, it references a type, and a dynamic field
+      definition is created matching *___<typename>.  Alternately, if 
+      subFieldSuffix is defined, that is used to create the subFields.
+      Example: if subFieldType="double", then the coordinates would be
+        indexed in fields myloc_0___double,myloc_1___double.
+      Example: if subFieldSuffix="_d" then the coordinates would be indexed
+        in fields myloc_0_d,myloc_1_d
+      The subFields are an implementation detail of the fieldType, and end
+      users normally should not need to know about them.
+     -->
+    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+    
+    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
+    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    
+    <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
+      For more information about this and other Spatial fields new to Solr 4, see:
+      http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
+    -->
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
+    
+    <fieldType name="text" class="solr.TextField" omitNorms="false">
+      <analyzer>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- A text field that only splits on whitespace for exact matching of words -->
+    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+        
+    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
+    <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldtype>
+    
+    <!-- A text field with defaults appropriate for English -->
+    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <!--
+        <filter class="solr.PorterStemFilterFactory"/>
+        -->
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+        
+    <!-- queries for paths match documents at that path, or in descendent paths -->
+    <fieldType name="descendent_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+    </fieldType>
+    
+    <!-- queries for paths match documents at that path, or in ancestor paths -->
+    <fieldType name="ancestor_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+    </fieldType>
+    
+  </types>
+  
+</schema>

--- a/solr_conf/conf_v6/solrconfig.xml
+++ b/solr_conf/conf_v6/solrconfig.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config>
+  <!-- NOTE: various comments and unused configuration possibilities have been purged
+     from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
+     as well as the default solrconfig file included with Solr -->
+  
+  <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
+  
+  <luceneMatchVersion>6.2.1</luceneMatchVersion>
+
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+  <!-- solr lib dirs -->
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
+  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-analysis-extras-\d.*\.jar" />
+  
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <requestHandler name="search" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+     <lst name="defaults">
+       <str name="defType">edismax</str>
+       <str name="echoParams">explicit</str>
+       <str name="q.alt">*:*</str>
+       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+       <int name="qs">1</int>
+       <int name="ps">2</int>
+       <float name="tie">0.01</float>
+       <!-- this qf and pf are used by default, if not otherwise specified by
+            client. The default blacklight_config will use these for the
+            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            below, which the default blacklight_config will specify for
+            those searches. You may also be interested in:
+            http://wiki.apache.org/solr/LocalParams
+       -->
+        <str name="qf">
+          id
+          active_fedora_model_ssi
+          title_tesim
+          author_tesim
+          subject_tesim
+          all_text_timv
+        </str>
+        <str name="pf">
+          all_text_timv^10
+        </str>
+
+       <str name="author_qf">
+          author_tesim
+       </str>
+       <str name="author_pf">
+       </str>
+       <str name="title_qf">
+          title_tesim
+       </str>
+       <str name="title_pf">
+       </str>
+       <str name="subject_qf">
+          subject_tesim
+       </str>
+       <str name="subject_pf">
+       </str>
+       
+       <str name="fl">
+         *, 
+         score
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.limit">50</str>
+       <str name="facet.field">active_fedora_model_ssi</str>
+       <str name="facet.field">subject_sim</str>
+       
+       <str name="spellcheck">true</str>
+       <str name="spellcheck.dictionary">default</str>
+       <str name="spellcheck.onlyMorePopular">true</str>
+       <str name="spellcheck.extendedResults">true</str>
+       <str name="spellcheck.collate">false</str>
+       <str name="spellcheck.count">5</str>
+
+     </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <requestHandler name="permissions" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="facet">off</str>
+      <str name="echoParams">all</str>
+      <str name="rows">1</str>
+      <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+      <str name="fl">
+        id,
+        access_ssim,
+        discover_access_group_ssim,discover_access_person_ssim,
+        read_access_group_ssim,read_access_person_ssim,
+        edit_access_group_ssim,edit_access_person_ssim,
+        depositor_ti,
+        embargo_release_date_dtsi
+        inheritable_access_ssim,
+        inheritable_discover_access_group_ssim,inheritable_discover_access_person_ssim,
+        inheritable_read_access_group_ssim,inheritable_read_access_person_ssim,
+        inheritable_edit_access_group_ssim,inheritable_edit_access_person_ssim,
+        inheritable_embargo_release_date_dtsi
+      </str>
+    </lst>
+  </requestHandler>
+  
+  <requestHandler name="standard" class="solr.SearchHandler">
+     <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <str name="defType">lucene</str>
+     </lst>
+  </requestHandler>
+
+  <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
+  <requestHandler name="document" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+      <str name="fl">*</str>
+      <str name="rows">1</str>
+      <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+    </lst>
+  </requestHandler>
+
+
+  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+    <str name="queryAnalyzerFieldType">textSpell</str>
+    <!-- Multiple "Spell Checkers" can be declared and used by this component
+      (e.g. for title_spell field)
+      -->
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">spell</str>
+      <str name="spellcheckIndexDir">./spell</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+  </searchComponent>
+  
+  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" /> 
+  
+  <requestDispatcher handleSelect="true" >
+    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
+  </requestDispatcher>
+  
+  <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
+  
+  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+    <lst name="invariants">
+      <str name="q">solrpingquery</str>
+    </lst>
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+    </lst>
+  </requestHandler>
+  
+  <!-- config for the admin interface --> 
+  <admin>
+    <defaultQuery>search</defaultQuery>
+  </admin>
+  
+</config>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ ROOT_PATH = Rails.root.join("spec")
 DUMMY_PATH = File.join(ROOT_PATH,"dummies")
 
 # Allow http connections on localhost
-WebMock.disable_net_connect!(:allow_localhost => true)
+WebMock.disable_net_connect!(:allow => ["memcached", "redis", "mongo", "solr", "fc381", "localhost", "127.0.0.1"])
 
 RSpec.configure do |config|
   # Let Rails do its thing with spec types

--- a/spec/support/redis_clear.rb
+++ b/spec/support/redis_clear.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
 
   config.before(:each) do
-    r = Redis.new
+    r = $redis
     keys = r.keys
     r.del *keys if keys.length > 0
   end

--- a/test-compose.yaml
+++ b/test-compose.yaml
@@ -1,0 +1,59 @@
+version: '2'
+services:
+  # Back-end services
+  memcached:
+    image: memcached
+  mongo:
+    image: mongo
+  redis:
+    image: redis
+  solr:
+    image: oregondigital/solr
+    build:
+      dockerfile: docker/Dockerfile-solr
+      context: .
+  fc381:
+    image: oregondigital/hydra-jetty:3.8.1-4.0
+    build:
+      dockerfile: docker/Dockerfile-hydra-jetty
+      context: .
+    command: bash -c "rm -f /opt/jetty/webapps/solr.war && java -jar start.jar"
+    volumes:
+      - ./tmp/cache/media:/oregondigital/media
+    ports:
+      - "18983:8983"
+
+  # PhantomJS compiled binary
+  phantomjs:
+    image: oregondigital/phantomjs
+    build:
+      dockerfile: docker/Dockerfile-phantomjs
+      context: .
+    command: cp bin/phantomjs /mnt/phantombin
+    volumes:
+      - ./phantombin:/mnt/phantombin
+
+  # OD dev image - just here to give the test compose some build info
+  od:
+    image: oregondigital/od1
+    build:
+      dockerfile: docker/Dockerfile-dev
+      context: .
+
+  # Actual test setup
+  test:
+    image: oregondigital/od1-test
+    build:
+      dockerfile: docker/Dockerfile-test
+      context: .
+    command: echo You must run tests manually!
+    links:
+      - memcached
+      - redis
+      - mongo
+      - solr
+      - fc381
+    volumes:
+      - ./tmp/cache/media:/oregondigital/media
+    env_file:
+      - docker/test-variables.env


### PR DESCRIPTION
This is squashed as requested, and includes all the following:

- Updates json to 1.8.3 due to build errors in 1.8.1
- Updates some of the bigger github gems to use shallow copies
- Updates redis setup to allow custom backend server
- Updates all environments to allow custom memcached servers
- Updates Fedora and solr configs to be environmentally configurable in
  all environments
- Sets up custom solr image with OD-specific core and configs
- Creates a phantomjs image with a prebuilt binary
- Wraps jetty inside custom image to isolate Fedora more easily
- Sets up dev-centric compose file for easily tying services together
- Creates a test image and compose file to keep test and dev separate
- Dev dockerfile is set up to cache an initial gem state while still
  re-running bundler when Gemfile changes, which speeds up dev when
  Gemfile has minor changes
- All old setup is retained to ensure CI servers and existing devs can
  continue to work without using docker