### PR TITLE
Feature/better docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 set_content
 jetty
+*.sqlite3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,13 +34,13 @@ services:
       - data-derby:/opt/jetty/fedora/default/derby
       - ./media:/oregondigital/media
   workers:
-    image: oregondigital/od1
+    image: oregondigital/od1-dev
     build:
       dockerfile: docker/Dockerfile-dev
       context: .
     volumes:
-      - ./db:/oregondigital/db/
-      - ./media:/oregondigital/media
+      - .:/oregondigital
+    entrypoint: ""
     command: bundle exec rake resque:work
     links:
       - memcached
@@ -52,16 +52,24 @@ services:
       - docker/web-variables.env
       - docker/resque-variables.env
 
+  # This is just here to help facilitate building the OD1 image; it isn't
+  # enabled when starting the web container
+  core:
+    image: oregondigital/od1
+    build:
+      dockerfile: docker/Dockerfile
+      context: .
+    entrypoint: /bin/false
+
   # Front-end stuff
   web:
-    image: oregondigital/od1
+    image: oregondigital/od1-dev
     build:
       dockerfile: docker/Dockerfile-dev
       context: .
     volumes:
-      - ./db:/oregondigital/db/
-      - ./media:/oregondigital/media
-    command: bash -c "rm -f /oregondigital/tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"
+      - .:/oregondigital
+      - ./docker/dev-entry.sh:/entrypoint.sh
     ports:
       - "3000:3000"
     links:
@@ -73,10 +81,11 @@ services:
     env_file:
       - docker/web-variables.env
   resquehead:
-    image: oregondigital/od1
+    image: oregondigital/od1-dev
     build:
       dockerfile: docker/Dockerfile-dev
       context: .
+    entrypoint: ""
     command: bundle exec resque-web -FL -r redis:6379
     ports:
       - "5678:5678"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,115 @@
+# Creates an image suitable for running the Rails stack for OD 1
+#
+# Build:
+#     docker build --rm -t oregondigital/od1 -f docker/Dockerfile .
+
+# TODO: Upgrade ubuntu!  Right now this just needs to work with what we have in
+# circleci, but longer-term this could get problematic when ubuntu 12 hits EOL.
+#
+# Known issues:
+# - VIPS install will need to be figured out for a newer Ubuntu
+# - Will need to test derivative generation for all types since CLI changes sometimes happen
+# - ffmpeg will need to be replaced, and libavcode-extra-53 definitely has to be replaced
+FROM ubuntu:12.04
+MAINTAINER Jeremy Echols <jechols@uoregon.edu>
+
+# apt won't find some libs if this isn't run
+RUN apt-get update
+
+# Dependencies for vips installer
+RUN apt-get install -y pkg-config
+RUN apt-get install -y python-software-properties software-properties-common
+
+# Vips!  This is very specific to Ubuntu 12.04, pulled out of vips-install.sh
+RUN add-apt-repository -y ppa:lyrasis/precise-backports
+RUN apt-get install -y automake build-essential gobject-introspection gtk-doc-tools libglib2.0-dev \
+                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff4-dev libexif-dev \
+                       libgsf-1-dev liblcms2-dev libxml2-dev swig libmagickcore-dev curl
+RUN mkdir -p /opt/libvips
+WORKDIR /opt/libvips
+RUN curl http://www.vips.ecs.soton.ac.uk/supported/7.42/vips-7.42.3.tar.gz | tar zx
+WORKDIR /opt/libvips/vips-7.42.3
+RUN ./configure --enable-debug=no --enable-docs=no --enable-cxx=yes --without-python --without-orc --without-fftw
+RUN make
+RUN make install
+RUN ldconfig
+
+# Various derivative libs
+RUN apt-get purge libreoffice*
+RUN add-apt-repository -y ppa:libreoffice/ppa
+RUN apt-get install -y poppler-utils poppler-data ghostscript libreoffice
+RUN apt-get install -y libmagic-dev libmagickwand-dev ffmpeg libvorbis-dev libavcodec-extra-53
+RUN apt-get install -y graphicsmagick
+
+# Database connection libraries
+RUN apt-get install -y libmysqlclient-dev
+RUN apt-get install -y libsqlite3-dev
+
+# Nodejs for compiling assets
+RUN apt-get install -y nodejs
+
+# We need git for all our github-hosted gems
+RUN apt-get install -y git
+
+# Dependencies for Ruby
+RUN apt-get install -y libssl-dev libreadline-dev
+
+# Grab Ruby manually - can't install the default for Ubuntu 12.04
+#
+# Make sure this comes after the big downloads, as it's more likely we'll
+# change our ruby version than, say, our vips version - at least until we deal
+# with a major change (like OS) that would require a ruby rebuild anyway
+RUN mkdir -p /opt/ruby
+WORKDIR /opt/ruby
+RUN curl https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz | tar zx
+WORKDIR /opt/ruby/ruby-2.2.5
+RUN ./configure
+RUN make
+RUN make install
+
+# Grab bundler for installing the gems
+RUN gem install bundler
+
+# Set an environment variable to store where the app is installed to inside
+# of the Docker image
+ENV INSTALL_PATH /oregondigital
+WORKDIR $INSTALL_PATH
+
+# Pull down set content first so code updates, which are more common than set
+# updates, don't re-run the set syncing process
+COPY docker/sync-sets.sh /sync-sets.sh
+RUN chmod +x /sync-sets.sh
+RUN /sync-sets.sh
+
+# Grab the current code from github so we can use this directly or overlay our
+# own code on top of it - this makes it close to a production image *and*
+# ensures that changes to things like Gemfile and Gemfile.lock don't re-pull
+# the entire list of gems
+RUN cd / && git clone --depth 1 https://github.com/OregonDigital/oregondigital.git $INSTALL_PATH
+
+# Install gems
+RUN bundle install --without development test
+
+# Link the set content repo inside OD
+RUN ln -s /opt/od_set_content /oregondigital/set_content
+COPY docker/link-set-content.sh /link-set-content.sh
+RUN chmod +x /link-set-content.sh
+RUN /link-set-content.sh
+
+RUN bundle exec rake tmp:create
+
+RUN mkdir -p /oregondigital/media/thumbnails
+RUN ln -s /oregondigital/media /oregondigital/public/media
+RUN ln -s /oregondigital/media/thumbnails /oregondigital/public/thumbnails
+
+# Expose a volume so that the web server can read assets
+VOLUME ["$INSTALL_PATH/public"]
+
+# Allow devs to override the app code entirely
+VOLUME ["$INSTALL_PATH/"]
+
+# /entrypoint.sh can be overwritten, but provides basic default behavior of
+# running the web server
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,134 +1,23 @@
-# Creates an image suitable for running the Rails stack for OD 1.  This is for
-# development at the moment; production Dockerizing will need tweaking to get
-# all the code baked into an image, possibly set up safer settings, etc.
+# Creates an image suitable for running the Rails stack in development and
+# testing.  You shouldn't push this image up, as it's concerned with making a
+# local image based on your current code.  It will not reflect general needs.
 #
 # Build:
-#     docker build --rm -t oregondigital/od1 -f docker/Dockerfile-dev .
-
-# TODO: Upgrade ubuntu!  Right now this just needs to work with what we have in
-# circleci, but longer-term this could get problematic when ubuntu 12 hits EOL.
-#
-# Known issues:
-# - VIPS install will need to be figured out for a newer Ubuntu
-# - Will need to test derivative generation for all types since CLI changes sometimes happen
-# - ffmpeg will need to be replaced, and libavcode-extra-53 definitely has to be replaced
-FROM ubuntu:12.04
+#     docker build --rm -t oregondigital/od1-dev -f docker/Dockerfile-dev .
+FROM oregondigital/od1
 MAINTAINER Jeremy Echols <jechols@uoregon.edu>
 
-# apt won't find some libs if this isn't run
-RUN apt-get update
-
-# Dependencies for vips installer
-RUN apt-get install -y pkg-config
-RUN apt-get install -y python-software-properties software-properties-common
-
-# Vips!  This is very specific to Ubuntu 12.04, pulled out of vips-install.sh
-RUN add-apt-repository -y ppa:lyrasis/precise-backports
-RUN apt-get install -y automake build-essential gobject-introspection gtk-doc-tools libglib2.0-dev \
-                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff4-dev libexif-dev \
-                       libgsf-1-dev liblcms2-dev libxml2-dev swig libmagickcore-dev curl
-RUN mkdir -p /opt/libvips
-WORKDIR /opt/libvips
-RUN curl http://www.vips.ecs.soton.ac.uk/supported/7.42/vips-7.42.3.tar.gz | tar zx
-WORKDIR /opt/libvips/vips-7.42.3
-RUN ./configure --enable-debug=no --enable-docs=no --enable-cxx=yes --without-python --without-orc --without-fftw
-RUN make
-RUN make install
-RUN ldconfig
-
-# Various derivative libs
-RUN apt-get purge libreoffice*
-RUN add-apt-repository -y ppa:libreoffice/ppa
-RUN apt-get install -y poppler-utils poppler-data ghostscript libreoffice
-RUN apt-get install -y libmagic-dev libmagickwand-dev ffmpeg libvorbis-dev libavcodec-extra-53
-RUN apt-get install -y graphicsmagick
-
-# Database connection libraries
-RUN apt-get install -y libmysqlclient-dev
-RUN apt-get install -y libsqlite3-dev
-
-# Nodejs for compiling assets
-RUN apt-get install -y nodejs
-
-# We need git for all our github-hosted gems
-RUN apt-get install -y git
-
-# Dependencies for Ruby
-RUN apt-get install -y libssl-dev libreadline-dev
-
-# Grab Ruby manually - can't install the default for Ubuntu 12.04
-#
-# Make sure this comes after the big downloads, as it's more likely we'll
-# change our ruby version than, say, our vips version - at least until we deal
-# with a major change (like OS) that would require a ruby rebuild anyway
-RUN mkdir -p /opt/ruby
-WORKDIR /opt/ruby
-RUN curl https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz | tar zx
-WORKDIR /opt/ruby/ruby-2.2.5
-RUN ./configure
-RUN make
-RUN make install
-
-# Set an environment variable to store where the app is installed to inside
-# of the Docker image
-ENV INSTALL_PATH /oregondigital
-RUN mkdir -p $INSTALL_PATH
-WORKDIR $INSTALL_PATH
-
-# Grab bundler for installing the gems
-RUN gem install bundler
-
-# Grab the current gemfiles from github so we have a place to start with
-# bundler - this ensures that changes to Gemfile and Gemfile.lock don't re-pull
-# the entire list of gems
-RUN curl -O https://raw.githubusercontent.com/OregonDigital/oregondigital/master/Gemfile
-RUN curl -O https://raw.githubusercontent.com/OregonDigital/oregondigital/master/Gemfile.lock
+# ???? - docker won't remove or rewrite .bundle/config via RUN commands, so I
+# just copy in an empty file.  No clue why this is giving me issues.
+COPY docker/empty /oregondigital/.bundle/config
 RUN bundle install
 
-# Pull down set content
-COPY docker/sync-sets.sh /sync-sets.sh
-RUN chmod +x /sync-sets.sh
-RUN /sync-sets.sh
-
-# Create symlinks
-COPY docker/link-set-content.sh /link-set-content.sh
-RUN chmod +x /link-set-content.sh
-RUN /link-set-content.sh
-
-# Let's create the temp dirs manually instead of using rake, which depends on
-# the app already being in place
-RUN mkdir -p tmp/sessions tmp/sockets tmp/pids tmp/cache/assets/development \
-             tmp/cache/assets/test tmp/cache/assets/production
-
-# Copy in OD code one piece at a time so we can trust what we end up with
-COPY app app
-COPY config config
-COPY config.ru config.ru
-COPY db db
-COPY lib lib
-COPY public public
-COPY Rakefile Rakefile
-COPY script script
-COPY spec spec
-COPY test test
-COPY vendor vendor
-
-# Now add the Gemfiles and re-bundle - this is redundant, I know, but it makes
-# development better by only pulling changed gems and not re-running a bunch of
-# extraneous steps
+# Add the local Gemfiles over what's in the OD1 image and bundle install again.
+# This seemingly-redundant step ensures that only the local changes are
+# reinstalled when dependency changes occur locally, rather than having to
+# re-pull all dev/test gems again.
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 RUN bundle install
 
-RUN mkdir -p /oregondigital/media/thumbnails
-RUN ln -s /oregondigital/media /oregondigital/public/media
-RUN ln -s /oregondigital/media/thumbnails /oregondigital/public/thumbnails
-
-# Expose a volume so that the web server can read assets
-VOLUME ["$INSTALL_PATH/public"]
-
-# Allow devs to override the app code entirely
-VOLUME ["$INSTALL_PATH/"]
-
-# The default command runs the web server
-CMD bundle exec rails s -p 3000 -b "0.0.0.0"
+RUN touch /var/firstrun

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -1,6 +1,0 @@
-# Creates an image suitable for running the OD 1 tests
-FROM oregondigital/od1
-MAINTAINER Jeremy Echols <jechols@uoregon.edu>
-
-# If you don't have a phantomJS binary, version 1.8.1, you need to run the phantomjs container to build it
-COPY ./phantombin/phantomjs /usr/bin/phantomjs

--- a/docker/dev-entry.sh
+++ b/docker/dev-entry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Re-link the set content, since dev will mount in local directories
+/bin/rm -f /oregondigital/set_content
+/bin/ln -s /opt/od_set_content /oregondigital/set_content
+/link-set-content.sh
+
+# Run database migrations and create an admin user if this is our first run.
+# This might re-run both tasks on one's local database, since db is mounted in
+# and the container may be removed between development sessions, but neither
+# task should hurt anything.  It just slows down the first run a bit.
+if [[ -f /var/firstrun ]]; then
+  bundle exec rake db:migrate
+  bundle exec rake admin_user
+  /bin/rm /var/firstrun
+fi
+
+# Start up puma
+rm -f /oregondigital/tmp/pids/server.pid
+bundle exec rails s -p 3000 -b "0.0.0.0"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Start up puma
+bundle exec rails s -p 3000 -b "0.0.0.0"

--- a/docker/link-set-content.sh
+++ b/docker/link-set-content.sh
@@ -3,7 +3,6 @@
 # Creates symlinks to set content for views and assets
 PATH=/oregondigital
 REPO_PATH="$PATH/set_content"
-GITFILE="$REPO_PATH/.git"
 ASSET_PATH="$PATH/app/assets"
 SET_JS_PATH="$ASSET_PATH/javascripts/sets"
 SET_IMG_PATH="$ASSET_PATH/images/sets"
@@ -16,14 +15,14 @@ SET_CONTENT_PATH="$PATH/app/views/sets"
 /bin/mkdir -p $SET_CONTENT_PATH
 
 remove_symlinks() {
-  /usr/bin/find $SET_JS_PATH -type l -exec rm {} \;
-  /usr/bin/find $SET_CSS_PATH -type l -exec rm {} \;
-  /usr/bin/find $SET_IMG_PATH -type l -exec rm {} \;
-  /usr/bin/find $SET_CONTENT_PATH -type l -exec rm {} \;
+  /usr/bin/find $SET_JS_PATH -type l -exec /bin/rm {} \;
+  /usr/bin/find $SET_CSS_PATH -type l -exec /bin/rm {} \;
+  /usr/bin/find $SET_IMG_PATH -type l -exec /bin/rm {} \;
+  /usr/bin/find $SET_CONTENT_PATH -type l -exec /bin/rm {} \;
 }
 
 create_symlinks() {
-  for setdir in $(/usr/bin/find $REPO_PATH -maxdepth 1 -type d -not -name ".*"); do
+  for setdir in $(/usr/bin/find -L $REPO_PATH -maxdepth 1 -type d -not -name ".*"); do
     setname=${setdir##*/}
 
     dir=$setdir/content

--- a/docker/sync-sets.sh
+++ b/docker/sync-sets.sh
@@ -2,14 +2,8 @@
 #
 # Syncs data from github for set content.  Meant to be run as part of an image
 # build; use the rake task to resync if necessary.
-PATH=/oregondigital
-REPO_PATH="$PATH/set_content"
+REPO_PATH="/opt/od_set_content"
 GITFILE="$REPO_PATH/.git"
-ASSET_PATH="$PATH/app/assets"
-SET_JS_PATH="$ASSET_PATH/javascripts/sets"
-SET_IMG_PATH="$ASSET_PATH/images/sets"
-SET_CSS_PATH="$ASSET_PATH/stylesheets/sets"
-SET_CONTENT_PATH="$PATH/app/views/sets"
 
 gitclone() {
   /usr/bin/git clone https://github.com/OregonDigital/oregon-digital-set-content.git $REPO_PATH

--- a/docker/test-entry.sh
+++ b/docker/test-entry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Re-link the set content, since dev will mount in local directories
+/bin/rm -f /oregondigital/set_content
+/bin/ln -s /opt/od_set_content /oregondigital/set_content
+/link-set-content.sh
+
+# run tests
+bundle exec rspec $@

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -30,6 +30,7 @@ dctest start memcached
 dctest start redis
 dctest start mongo
 dctest start solr
+dctest run phantomjs
 
 # Fedora is the slow one, so we wait until we get a response
 echo "Waiting for Fedora to start"

--- a/test-compose.yaml
+++ b/test-compose.yaml
@@ -19,34 +19,25 @@ services:
       context: .
     command: bash -c "rm -f /opt/jetty/webapps/solr.war && java -jar start.jar"
     volumes:
-      - ./tmp/cache/media:/oregondigital/media
+      - ./media:/oregondigital/media
     ports:
       - "18983:8983"
 
-  # PhantomJS compiled binary
+  # PhantomJS compiled binary - pull the image from Dockerhub if at all
+  # possible - we don't tell compose how to build it because it's REALLY slow,
+  # and we only need the compiled binary, AND it's only critical for testing.
   phantomjs:
-    image: oregondigital/phantomjs
-    build:
-      dockerfile: docker/Dockerfile-phantomjs
-      context: .
+    image: oregondigital/phantomjs:1.8.1
     command: cp bin/phantomjs /mnt/phantombin
     volumes:
       - ./phantombin:/mnt/phantombin
-
-  # OD dev image - just here to give the test compose some build info
-  od:
-    image: oregondigital/od1
-    build:
-      dockerfile: docker/Dockerfile-dev
-      context: .
 
   # Actual test setup
   test:
     image: oregondigital/od1-test
     build:
-      dockerfile: docker/Dockerfile-test
+      dockerfile: docker/Dockerfile-dev
       context: .
-    command: echo You must run tests manually!
     links:
       - memcached
       - redis
@@ -54,6 +45,8 @@ services:
       - solr
       - fc381
     volumes:
-      - ./tmp/cache/media:/oregondigital/media
+      - .:/oregondigital
+      - ./phantombin/phantomjs:/usr/bin/phantomjs
+      - ./docker/test-entry.sh:/entrypoint.sh
     env_file:
       - docker/test-variables.env


### PR DESCRIPTION
Most important fixes:

- Docker will never accidentally put your local sqlite databases into an image
- Sets up a more generic Dockerfile for building a "base" image using the
  latest master checkout of the code.  This should be closer to what we'd
  want in a production environment.
- Reorders some of the docker instructions to minimize the costs of the
  more frequent changes.
- Test and dev now use a simple sub-image of the od1 base image which
  installs dev and test gems.  Changes to things like the app code will no
  longer result in having to rebundle gems.
- The phantomjs image no longer auto-builds in order to avoid unexpected
  wastes of time.  Instead, devs will want to pull it before doing work to
  ensure they have access to the binary.
- Several issues with the set content linking have been fixed.
- Compose files are updated to mount the entire local directory structure
  for development and testing so the latest code is always in use
  *without* needing an image rebuild
- On first run of the dev image, the database and an admin user are
  created automatically
- Test containers are stopped after tests run, rather than eating up
  CPU/RAM forever
- The above is true unless tests are run with `--quick`, which allows
  one to keep containers up and running to make the dev-test loop faster