### PR TITLE
Fix bulk task spec

### DIFF
--- a/app/views/bulk_tasks/show.html.erb
+++ b/app/views/bulk_tasks/show.html.erb
@@ -20,7 +20,7 @@
       <tbody>
         <% @task.bulk_task_children.each do |child| %>
           <tr>
-            <td><%=link_to child.id, child %></td>
+            <td class="child-link"><%=link_to child.id, child %></td>
             <% if child.ingested_pid.blank? %>
               <td></td>
             <% else %>

--- a/spec/features/bulk_task_spec.rb
+++ b/spec/features/bulk_task_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bulk tasks', :js => true do
+describe 'bulk tasks', :js => false do
   let(:admin) {FactoryGirl.create(:admin)}
   let(:asset) do
     a = GenericAsset.new
@@ -251,8 +251,8 @@ describe 'bulk tasks', :js => true do
           end
           context "on the child page" do
             before do
-              visit bulk_task_child_path(BulkTaskChild.last.id)
-              sleep(1)
+              click_link "bulkloads"
+              find("td.child-link a").click
             end
             it "should have the error" do
               expect(page).to have_content("Failed During reviewing")


### PR DESCRIPTION
- Removes JS requirement to speed up tests since they don't need JS
- Clicks the child task link directly instead of assuming the last one
  in the database will work