### PR TITLE
Feature/admin

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -25,31 +25,31 @@
           <%= link_to t('blacklight.header_links.search_history'), search_history_path %>
         </li>
 
-          <% if can?(:show, Role) -%>
-        <li>
-            <%= link_to "Roles", role_management.roles_path %>
-        </li>
-          <% end -%>
-
-          <% if can?(:review, GenericAsset) -%>
-        <li>
-            <%= link_to "Review", reviewer_index_path %>
-        </li>
-          <% end -%>
-
 
         <% if can?(:create, GenericAsset) %>
-        <li>
-          <%= link_to "Ingest", ingest_index_path %>
-        </li>
+          <li>
+            <%= link_to "Ingest", ingest_index_path %>
+          </li>
         <% end %>
 
+        <% if can?(:review, GenericAsset) -%>
+          <li>
+            <%= link_to "Review", reviewer_index_path %>
+          </li>
+        <% end -%>
 
         <% if can?(:create, ::Template) %>
-        <li>
-          <%= link_to "Templates", templates_path %>
-        </li>
+          <li>
+            <%= link_to "Templates", templates_path %>
+          </li>
         <% end %>
+
+        <% if can?(:create, GenericAsset) %>
+          <li>
+            <%= link_to "Admin", "/admin" %>
+          </li>
+        <% end %>
+
         <li><a href="/copyright">Copyright</a></li>
         <li class="last"><%= link_to "Contact", contact_path %></li>
 

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -22,25 +22,21 @@
   </div>
   <div class="util-links-auth">
     <div class="admin">
-      <% if can?(:show, Role) -%>
-        <%= link_to "Roles", role_management.roles_path %>
-        <% content_for :body_class, "admins" %>
-      <% end -%>
-      <% if can?(:review, GenericAsset) -%>
-        -
-        <%= link_to "Review", reviewer_index_path %>
-      <% end -%>
 
       <% if can?(:create, GenericAsset) %>
-        - <%= link_to "Ingest", ingest_index_path %>
+        <%= link_to "Ingest", ingest_index_path %>
       <% end %>
+
+      <% if can?(:review, GenericAsset) -%>
+        - <%= link_to "Review", reviewer_index_path %>
+      <% end -%>
 
       <% if can?(:create, ::Template) %>
         - <%= link_to "Templates", templates_path %>
       <% end %>
 
-      <% if can?(:destroy, GenericAsset) %>
-        - <%= link_to "Destroyed Items", destroyed_index_path %>
+      <% if can?(:create, GenericAsset) %>
+        - <%= link_to "Admin", '/admin' %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/sets/_footer.html.erb
+++ b/app/views/shared/sets/_footer.html.erb
@@ -32,9 +32,9 @@
         </ul>
         <ul>
           <li class="first">
-            <% if can?(:show, Role) -%>
-              <%= link_to "Roles", role_management.roles_path %>
-            <% end -%>
+            <% if can?(:create, GenericAsset) %>
+              <%= link_to "Ingest", ingest_index_path %>
+            <% end %>
           </li>
           <li>
             <% if can?(:review, GenericAsset) -%>
@@ -42,13 +42,13 @@
             <% end -%>
           </li>
           <li>
-            <% if can?(:create, GenericAsset) %>
-              <%= link_to "Ingest", ingest_index_path %>
+            <% if can?(:create, ::Template) %>
+              <%= link_to "Templates", templates_path %>
             <% end %>
           </li>
           <li class="last">
-            <% if can?(:create, ::Template) %>
-              <%= link_to "Templates", templates_path %>
+            <% if can?(:create, GenericAsset) %>
+              <%= link_to "Admin", "/admin" %>
             <% end %>
           </li>
         </ul>

--- a/app/views/shared/sets/_user_util_links.html.erb
+++ b/app/views/shared/sets/_user_util_links.html.erb
@@ -25,26 +25,32 @@
       <%= link_to t('blacklight.header_links.search_history'), search_history_path %>
     </li>
 
-    <% if can?(:show, Role) -%>
+
+    <% if can?(:create, GenericAsset) %>
       <li class="leaf">
-        <%= link_to "Roles", role_management.roles_path %>
+        <%= link_to "Ingest", ingest_index_path %>
       </li>
-    <% end -%>
+    <% end %>
+
     <% if can?(:review, GenericAsset) -%>
       <li class="leaf">
         <%= link_to "Review", reviewer_index_path %>
+      </li>
     <% end -%>
-    </li>
-    <li class="leaf">
-    <% if can?(:create, GenericAsset) %>
-      <%= link_to "Ingest", ingest_index_path %>
-    <% end %>
-    </li>
-    <li class="leaf">
+
     <% if can?(:create, ::Template) %>
-      <%= link_to "Templates", templates_path %>
+      <li class="leaf">
+        <%= link_to "Templates", templates_path %>
+      </li>
     <% end %>
-    </li>
+
+    <% if can?(:create, GenericAsset) -%>
+      <li class="leaf">
+        <%= link_to "Admin", "/admin" %>
+      </li>
+    <% end -%>
+
+
     <% if can?(:show, Role) -%>
     <% else %>
       <li class="leaf">

--- a/app/views/static/admin.html.erb
+++ b/app/views/static/admin.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, 'Admin' %>
+<div id="content" class="span12">
+
+  <h2>Admin</h2>
+
+  <% if can?(:show, Role) -%>
+    <p><%= link_to "Roles", role_management.roles_path %></p>
+  <% end -%>
+
+  <% if current_user and current_user.admin? %>
+    <p><%= link_to "Resque Workers", '/resque/overview' %></p>
+  <% end %>
+
+  <% if current_user and current_user.admin? %>
+    <p><%= link_to "Bulk Tasks", bulk_tasks_path %></p>
+  <% end %>
+
+  <% if can?(:destroy, GenericAsset) %>
+    <p><%= link_to "Destroyed Items", destroyed_index_path %></p>
+  <% end %>
+
+  <p><a href="https://github.com/OregonDigital/oregondigital/wiki">GitHub Wiki</a></p>
+
+  <p><a href="https://docs.google.com/spreadsheets/d/1nnJz49oqstQLF2PFBn5ZvWfWdF-8PVl5TFL1EMotQrA/edit?usp=sharing">Metadata Dictionary</a></p>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Oregondigital::Application.routes.draw do
   resources :resource, :only => [:show]
 
   # Static Pages
-  get ':action' => 'static#:action', :constraints => { :action => /copyright|help|controlled_vocabularies|vocabularies/ }, :as => :static
+  get ':action' => 'static#:action', :constraints => { :action => /admin|copyright|help|controlled_vocabularies|vocabularies/ }, :as => :static
 
   # Thumbnails
   get '/thumbnails/:id', :to => 'thumbnails#thumbnail_links'

--- a/spec/features/role_manager_spec.rb
+++ b/spec/features/role_manager_spec.rb
@@ -5,7 +5,7 @@ describe "admin panel links" do
   let(:admin) { FactoryGirl.create(:admin) }
 
   before(:each) do
-    visit root_path
+    visit "/admin"
   end
   context "when a user is logged in" do
     context "and they are an admin" do

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -5,11 +5,9 @@ describe "Role management" do
 
   before(:each) do
     capybara_login(user)
-    visit root_path
+    visit "/admin"
 
-    within(".utils .admin") do
-      click_link "Roles"
-    end
+    click_link "Roles"
   end
 
   it "should allow an admin to create a role" do


### PR DESCRIPTION
Create a new static Admin page to provide better access to common tools
while not cluttering up the nav bar links and footers. Moved the Roles
link out to the Admin page to make room. I thought
Ingest/Review/Templates was more in order of use. If someone happens to
visit the Admin page without access they still get links to the wiki and
metadata dictionary.

![od-admin](https://cloud.githubusercontent.com/assets/2293544/19819042/917e7214-9d07-11e6-8b13-503bfb2e3dd2.png)
