### PR TITLE
Change ITIS fetch to always be https

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/subject.rb
+++ b/lib/oregon_digital/controlled_vocabularies/subject.rb
@@ -17,20 +17,28 @@ module OregonDigital::ControlledVocabularies
     use_vocabulary :wikidata
     use_vocabulary :ulan
 
+    # Call custom fetch methods for ITIS or uBio URLs.
     # Make wikidata entity URIs usable to fetch.
     # Our gems don't handle their https redirect, and JSON is the default response which we have errors parsing, so force to NT.
     # For fetch purposes only, change URI from http://www.wikidata.org/entity/Q5343795 to https://www.wikidata.org/wiki/Special:EntityData/Q5343795.nt
     def fetch
-      if self.rdf_subject.to_s.include?('wikidata') then
-        self.rdf_subject.to_s.gsub!('http://www.wikidata.org/entity/', 'https://www.wikidata.org/wiki/Special:EntityData/')
-        self.rdf_subject.to_s.concat('.nt')
-      end
+      # Call custom fetch methods for ITIS.gov and uBio authority URLs
+      if self.rdf_subject.to_s.include?('itis.gov')
+        fetch_itis
+      elsif self.rdf_subject.to_s.include?('ubio.org')
+        fetch_ubio
+      else 
+        if self.rdf_subject.to_s.include?('wikidata') then
+          self.rdf_subject.to_s.gsub!('http://www.wikidata.org/entity/', 'https://www.wikidata.org/wiki/Special:EntityData/')
+          self.rdf_subject.to_s.concat('.nt')
+        end
 
-      super
+        super
 
-      if self.rdf_subject.to_s.include?('wikidata') then
-        self.rdf_subject.to_s.gsub!('https://www.wikidata.org/wiki/Special:EntityData/', 'http://www.wikidata.org/entity/')
-        self.rdf_subject.to_s.gsub!('.nt', '')
+        if self.rdf_subject.to_s.include?('wikidata') then
+          self.rdf_subject.to_s.gsub!('https://www.wikidata.org/wiki/Special:EntityData/', 'http://www.wikidata.org/entity/')
+          self.rdf_subject.to_s.gsub!('.nt', '')
+        end
       end
     end
 

--- a/lib/oregon_digital/rdf/controlled.rb
+++ b/lib/oregon_digital/rdf/controlled.rb
@@ -78,7 +78,7 @@ module OregonDigital::RDF
     # More info: http://www.itis.gov/web_service.html
     def fetch_itis
       uri = self.rdf_subject.to_s
-      tsn = uri.sub 'http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=', ''
+      tsn = uri.sub 'https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=', ''
       json_url = "http://www.itis.gov/ITISWebService/jsonservice/getFullRecordFromTSN?tsn=#{tsn}"
 
       response = RestClient.get json_url, {accept: :json}

--- a/lib/oregon_digital/vocabularies/itis.rb
+++ b/lib/oregon_digital/vocabularies/itis.rb
@@ -1,6 +1,6 @@
 # This file generated automatically using vocab-fetch from http://www.itis.gov
 require 'rdf'
 module OregonDigital::Vocabularies
-  class ITIS < ::RDF::Vocabulary("http://www.itis.gov/")
+  class ITIS < ::RDF::Vocabulary("https://www.itis.gov/")
   end
 end


### PR DESCRIPTION
Add fetch_itis and fetch_ubio calls to Subject controlled vocab.
Change ITIS vocab definition to 'https'. Change fetch_itis to use
'https'.

Fixes #1078 
