### PR TITLE
Feature/cvs

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,2 +1,15 @@
 class StaticController < ApplicationController
+
+  def controlled_vocabularies
+    @controlled_vocabs = []
+
+    Datastream::OregonRDF.properties.map do |key, property|
+      next if property[:class_name].nil?
+      next if property[:class_name].to_s == "GenericAsset" || property[:class_name].to_s == "GenericCollection"
+
+      @controlled_vocabs << property[:class_name]
+    end 
+
+    @controlled_vocabs = @controlled_vocabs.uniq
+  end
 end

--- a/app/views/static/controlled_vocabularies.html.erb
+++ b/app/views/static/controlled_vocabularies.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, 'Controlled Vocabularies' %>
+<div id="content" class="span12">
+
+  <h2>Controlled Vocabularies</h2>
+
+  <p>This lists all of the controlled vocabularies configured in Oregon Digital. They group together <a href="/vocabularies">Vocabularies</a> already defined, and when specified on a property, control what Vocabularies are usable.</p>
+
+  <ul>
+    <% @controlled_vocabs.each do |cv| %>
+      <li><h4><%= cv %></h4>
+      <b>Usable Vocabularies:</b>
+        <% cv.vocabularies.each do |vocab| %>
+          <%= link_to vocab[0], "/vocabularies##{vocab[0]}" %>,
+        <% end %>
+      <br/>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/static/controlled_vocabularies.html.erb
+++ b/app/views/static/controlled_vocabularies.html.erb
@@ -9,8 +9,8 @@
     <% @controlled_vocabs.each do |cv| %>
       <li><h4><%= cv %></h4>
       <b>Usable Vocabularies:</b>
-        <% cv.vocabularies.each do |vocab| %>
-          <%= link_to vocab[0], "/vocabularies##{vocab[0]}" %>,
+        <% cv.vocabularies.to_a.each do |vocab| %>
+          <%= link_to vocab[0], "/vocabularies##{vocab[0]}" %><%= "," unless vocab == cv.vocabularies.to_a.last %>
         <% end %>
       <br/>
       </li>

--- a/app/views/static/vocabularies.html.erb
+++ b/app/views/static/vocabularies.html.erb
@@ -1,0 +1,15 @@
+<%= content_for :page_title, 'Vocabularies' %>
+<div id="content" class="span12">
+
+  <h2>Vocabularies</h2>
+
+  <p>These Vocabularies are defined in Oregon Digital, and are combined together in <a href="/controlled_vocabularies">Controlled Vocabularies</a> to control what values are allowed on a property.</p>
+
+  <ul>
+    <% RDF_VOCABS.sort.each do |vocab| %>
+      <li><a name="<%= vocab[0] %>"></a><%= vocab[0] %> - <%= link_to vocab[1].first[1], vocab[1].first[1] %></li>
+    <% end %>
+    </ul>
+  <p><%= RDF_VOCABS.count %> total</p>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Oregondigital::Application.routes.draw do
   resources :resource, :only => [:show]
 
   # Static Pages
-  get ':action' => 'static#:action', :constraints => { :action => /copyright|help/ }, :as => :static
+  get ':action' => 'static#:action', :constraints => { :action => /copyright|help|controlled_vocabularies|vocabularies/ }, :as => :static
 
   # Thumbnails
   get '/thumbnails/:id', :to => 'thumbnails#thumbnail_links'

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe StaticController do
+  describe "#controlled_vocabularies" do
+    context "When a user visits the page" do
+      before do
+        get :controlled_vocabularies
+      end
+      it "should work" do
+        expect(response).to be_success
+      end
+    end
+  end
+end

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -11,4 +11,18 @@ describe "Static Pages" do
     end
   end
 
+  context "Controlled Vocabularies" do
+    before(:each) do
+      visit '/controlled_vocabularies'
+    end
+    it "should include OregonDigital::ControlledVocabularies::Creator" do
+      expect(page).to have_content('OregonDigital::ControlledVocabularies::Creator')
+    end
+    it "should not include GenericCollection" do
+      expect(page).not_to have_content('GenericCollection')
+    end
+    it "should not include GenericAsset" do
+      expect(page).not_to have_content('GenericAsset')
+    end
+  end
 end


### PR DESCRIPTION
Start of work to better show what Vocabularies and Controlled Vocabularies we have set up in OD.

For now these aren't linked from anywhere, though they could first go on the new Admin page once that is merged in. 

I'd also like to somehow link the CV page from the Ingest Form, possibly alongside each form field once one is selected.

Here's what the pages look like right now:

![od-controlledvocabs](https://cloud.githubusercontent.com/assets/2293544/20074131/cd43c6b2-a4e3-11e6-92e0-2e0bd7c154b8.png)
![od-vocabs](https://cloud.githubusercontent.com/assets/2293544/20074130/cd434200-a4e3-11e6-9adc-89f0f65260c1.png)


