### PR TITLE
Add support for SPAR Ontologies Mediatype URIs

### DIFF
--- a/config/initializers/controlled_vocabularies.rb
+++ b/config/initializers/controlled_vocabularies.rb
@@ -19,6 +19,7 @@ RDF_VOCABS = {
   :uonames              =>  { :prefix => 'http://opaquenamespace.org/ns/uo-names/', :source => 'https://raw.github.com/OregonDigital/opaque_ns/master/uo/names.jsonld', :strict => false, :fetch => false },
   :rights               =>  { :prefix => 'http://opaquenamespace.org/ns/rights/', :source => 'https://raw.github.com/OregonDigital/opaque_ns/master/rights.jsonld', :strict => true },
   :eurights             =>  { :prefix => 'http://www.europeana.eu/rights/', :source => 'https://raw.github.com/OregonDigital/opaque_ns/master/eurights/rightsstatements.nt', :strict => true },
+  :mediatype            =>  { :prefix => 'https://w3id.org/spar/mediatype/', :strict => false, :fetch => false },
   :mimetype             =>  { :prefix => 'http://purl.org/NET/mediatypes/', :fetch => false },
   :oregondigital        =>  { :prefix => 'http://opaquenamespace.org/ns/', :source => 'https://raw.github.com/OregonDigital/opaque_ns/master/opaquenamespace.jsonld', :strict => false, :fetch => false },
   :oregon_universities  =>  { :prefix => 'http://dbpedia.org/resource/', :source => 'https://raw.github.com/OregonDigital/opaque_ns/master/oregon_universities.jsonld', :strict => false, :fetch => false },

--- a/lib/oregon_digital/controlled_vocabularies/format.rb
+++ b/lib/oregon_digital/controlled_vocabularies/format.rb
@@ -2,7 +2,27 @@ module OregonDigital::ControlledVocabularies
   class Format < ActiveFedora::Rdf::Resource
     include OregonDigital::RDF::Controlled
 
+    use_vocabulary :mediatype
     use_vocabulary :mimetype
 
+    # Custom fetch method for SPAR Ontologies Mediatype URIs
+    # to bypass HTTP redirects and go straight to RDF/XML file
+    def fetch
+      if self.rdf_subject.to_s.include?('spar')
+        uri = self.rdf_subject.to_s
+        xml_url = uri.sub 'https://w3id.org/spar/', 'http://www.sparontologies.net/'
+        xml_url.concat('.rdf')
+
+        response = RestClient.get xml_url, {accept: :xml}
+        xmldoc = Nokogiri::XML(response)
+        new_label = xmldoc.at_xpath("/rdf:RDF/rdf:Description/rdfs:label/text()")
+
+        self << RDF::Statement.new(rdf_subject, RDF::SKOS.prefLabel, new_label)
+
+        persist!
+      else
+        super
+      end
+    end
   end
 end

--- a/lib/oregon_digital/vocabularies/mediatype.rb
+++ b/lib/oregon_digital/vocabularies/mediatype.rb
@@ -1,0 +1,6 @@
+require 'rdf'
+module OregonDigital::Vocabularies
+  class MEDIATYPE < ::RDF::Vocabulary("https://w3id.org/spar/mediatype/")
+
+  end
+end


### PR DESCRIPTION
Add the SPAR Ontologies Mediatype URIs as a vocabulary and add to Format
controlled vocabulary. Use custom fetch method to go straight to the
RDF/XML file. The redirects from https://w3id.org/spar to
http://www.sparontologies.net break content negotiation with our
current setup.

Fixes #1084 

Also related to #940 