### PR TITLE
Add URI button to Ingest Form on controlled fields

### DIFF
--- a/app/assets/stylesheets/ingest.css.scss
+++ b/app/assets/stylesheets/ingest.css.scss
@@ -40,6 +40,10 @@
     vertical-align: top;
   }
 
+  .btn-info {
+    margin-right: 20px;
+  }
+
   .add-link-wrapper {
     margin-left: 20px;
   }

--- a/app/views/ingest/_ingest_fields.html.erb
+++ b/app/views/ingest/_ingest_fields.html.erb
@@ -3,6 +3,10 @@
 
   <div class="control-group ingest-control">
     <div class="controls">
+      <% if f.object.internal %>
+        <%= link_to "URI", f.object.internal.to_s, :class => "btn btn-info", :target => '_blank' %>
+      <% end %>
+
       <%= link_to_remove_ingest_association(f) %>
     </div>
   </div>

--- a/spec/features/ingest_form_spec.rb
+++ b/spec/features/ingest_form_spec.rb
@@ -281,11 +281,14 @@ describe "(Ingest Form)" do
         expect(asset.descMetadata.lcsubject.collect {|s| s.rdf_subject}).to eq([subject1, subject2])
       end
 
-      it "should display the label on a subsequent edit" do
+      it "should display the label and URI button on a subsequent edit" do
         click_the_ingest_button
         visit_edit_form_url(@pid)
         expect(page).to include_ingest_fields_for("subject", "lcsubject", label1)
         expect(page).to include_ingest_fields_for("subject", "lcsubject", label2)
+
+        expect(page).to have_selector(:link_or_button, 'URI')
+        expect(page).to have_link(nil, href: subject1)
       end
 
       it "should display the label to the public" do


### PR DESCRIPTION
This adds a URI button when an Ingest Form field is controlled, so
instead of just showing the label the URI underneath it is also available. Button opens the URI in a new window, or can be used for copying the link to clipboard.

Fixes #1098 

Here's what it looks like:
![ingest_uri_button](https://cloud.githubusercontent.com/assets/2293544/21249673/829f29ba-c2f4-11e6-922c-a98c3d853da1.png)



