### PR TITLE
Create dropdown for sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Local Development Setup
 git clone git@github.com:OregonDigital/oregondigital.git
 
 # Start the whole stack - on your first run, this can take a while to download
-all the necessary images
+# all the necessary images
 docker-compose up -d
 ```
 

--- a/app/helpers/ingest_helper.rb
+++ b/app/helpers/ingest_helper.rb
@@ -44,12 +44,33 @@ module IngestHelper
       :wrapper_html => {:class => "ingest-control type"}
     )
 
-    controls << f.input(
-      :value,
+    input_args = {
       :input_html => {:class => "input-xxlarge value-field"},
       :label_html => {:class => "sr-only"},
       :wrapper_html => {:class => "ingest-control value"}
-    )
+    }
+
+    # SUPER HACK!  If we're looking at sets, we don't want free-text, we want a
+    # drop-down.  Ideally we'd have a nicer way to make any given type do this,
+    # but the grouping dropdown makes it really tough without some painful new
+    # configurable ingest map format combined with JavaScript that swaps a
+    # dropdown over the text input magically
+    if f.object.group.to_sym == :collection
+      set_pids = ActiveFedora::SolrService.query(
+        "has_model_ssim:#{RSolr.escape("info:fedora/afmodel:GenericCollection")}",
+        :rows => 100000
+      )
+      set_options = set_pids.map do |pid|
+        set = GenericCollection.load_instance_from_solr(pid["id"], pid)
+        [set.title,  "http://oregondigital.org/resource/#{set.pid}"]
+      end
+
+      input_args[:collection] = set_options
+      input_args[:selected] = f.object.internal
+      input_args[:include_blank] = true
+    end
+
+    controls << f.input(:value, input_args)
 
     if f.object.cloneable?
       controls << f.input(
@@ -62,7 +83,10 @@ module IngestHelper
       )
     end
 
-    controls << f.hidden_field(:internal, :class => "internal-field")
+    # Super hack, continued: don't put an internal field on the form for sets
+    if f.object.group.to_sym != :collection
+      controls << f.hidden_field(:internal, :class => "internal-field")
+    end
 
     return controls.reduce { |list, next_control| list << next_control }
   end

--- a/config/initializers/ingest_form_map.rb
+++ b/config/initializers/ingest_form_map.rb
@@ -202,9 +202,13 @@ INGEST_MAP = {
     technique: "descMetadata.technique",
   },
 
-  grouping: {
+  # DO NOT put anything in here that isn't meant to be some type of OregonDigital set
+  collection: {
     set: "descMetadata.set",
     primarySet: "descMetadata.primarySet",
+  },
+
+  grouping: {
     exhibit: "descMetadata.exhibit",
   },
 

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -52,7 +52,6 @@ dcrun "rm -f /oregondigital/tmp/capybara/*"
 if [[ $quick == 0 ]]; then
   dcrun "rm -f /oregondigital/db/test.db"
   dcrun "bundle exec rake db:migrate"
-  dcrun "bundle exec rake db:test:create"
 fi
 
 target=${@:-spec/}

--- a/lib/oregon_digital/catalog/decorators.rb
+++ b/lib/oregon_digital/catalog/decorators.rb
@@ -4,14 +4,14 @@ module OregonDigital
     # This module is for decorators which give us better view logic without hacking Blacklight,
     # instantiating objects in the views, etc.
     module Decorators
-      extend ActiveSupport::Concern
+      extend ::ActiveSupport::Concern
       included do
         def decorated_object
-          @document_object ||= ActiveFedora::Base.load_instance_from_solr(params[:id], @document)
+          @document_object ||= ::ActiveFedora::Base.load_instance_from_solr(params[:id], @document)
           begin
             @decorated_object ||= @document_object.decorate
-          rescue Draper::UninferrableDecoratorError
-            @decorated_object = GenericAssetDecorator.new(@document_object)
+          rescue ::Draper::UninferrableDecoratorError
+            @decorated_object = ::GenericAssetDecorator.new(@document_object)
           end
 
           return @decorated_object

--- a/lib/oregon_digital/controlled_vocabularies/set.rb
+++ b/lib/oregon_digital/controlled_vocabularies/set.rb
@@ -7,31 +7,5 @@ module OregonDigital::ControlledVocabularies
     end
 
     use_vocabulary :set
-
-    class QaSet
-      attr_accessor :response, :raw_response
-
-      def initialize(parent=nil)
-        @parent = parent
-      end
-
-      # Pulls names and ids of GenericCollection objects from Solr.
-      # `sub_authority` is ignored for sets.
-      def search(q, sub_authority=nil)
-        self.response = []
-        field = Solrizer.solr_name("desc_metadata__title", :searchable)
-        for set in GenericCollection.reviewed.where("#{field}:*#{q}*").to_a
-          resource = set.resource
-          response << {:id => resource.rdf_subject.to_s, :label => resource.rdf_label.first}
-        end
-      end
-
-      # TermsController requires this for now
-      def results
-        self.response
-      end
-    end
-
-    @qa_interface = QaSet.new
   end
 end

--- a/spec/features/ingest_form_spec.rb
+++ b/spec/features/ingest_form_spec.rb
@@ -235,7 +235,7 @@ describe "(Ingest Form)" do
       before do
         collection
         visit_ingest_url
-        choose_controlled_vocabulary_item("grouping", "set","Ala",collection.title, collection.resource.rdf_subject.to_s) 
+        choose_collection("set", collection.title)
       end
       it "should store the internal URI" do
         click_the_ingest_button

--- a/spec/features/templates_spec.rb
+++ b/spec/features/templates_spec.rb
@@ -76,7 +76,14 @@ describe "(Administration of templates)", :js => true do
   end
 
   context "The 'new template' form" do
+    let(:collection) do
+      c = FactoryGirl.create(:generic_collection, :title => "Alabama")
+      c.review!
+      c
+    end
+
     before(:each) do
+      collection
       visit "/templates"
       click_link "Create new template"
     end
@@ -99,13 +106,7 @@ describe "(Administration of templates)", :js => true do
       end
 
       context "with a set" do
-        let(:collection) do
-          c = FactoryGirl.create(:generic_collection, :title => "Alabama")
-          c.review!
-          c
-        end
         before do
-          collection
           choose_collection("set", collection.title)
         end
         it "should succeed" do
@@ -119,7 +120,8 @@ describe "(Administration of templates)", :js => true do
             click_link "Edit My First Template (tm)"
           end
           it "should show that set's value" do
-            expect(page).to include_ingest_fields_for("grouping", "set", collection.title)
+            expect(page).to include_ingest_fields_for("collection", "set",
+                "http://oregondigital.org/resource/#{collection.pid}")
           end
         end
       end

--- a/spec/features/templates_spec.rb
+++ b/spec/features/templates_spec.rb
@@ -106,7 +106,7 @@ describe "(Administration of templates)", :js => true do
         end
         before do
           collection
-          choose_controlled_vocabulary_item("grouping", "set","Ala",collection.title, collection.resource.rdf_subject.to_s) 
+          choose_collection("set", collection.title)
         end
         it "should succeed" do
           find(:css, 'input[type=submit]').click

--- a/spec/models/generic_collection_spec.rb
+++ b/spec/models/generic_collection_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe GenericCollection do
   it_behaves_like 'a collection'
-  it_behaves_like 'a Questioning Authority interface'
   subject {FactoryGirl.build(:generic_collection)}
 
   describe '#resource' do

--- a/spec/support/ingest_form.rb
+++ b/spec/support/ingest_form.rb
@@ -37,6 +37,16 @@ def fill_in_ingest_data(group, type, value, position = 0, clone = false)
   end
 end
 
+def choose_collection(type, value)
+  type = OregonDigital::Metadata::FieldTypeLabel.for(type)
+  nodes = ingest_group_nodes("collection")
+  node = nodes[0]
+  within(node) do
+    select(type, :from => "Type")
+    select(value, :from => "Value")
+  end
+end
+
 def choose_controlled_vocabulary_item(group, type, search, pick, internal, position = 0)
   # Expectations are here to ensure tests for CV stuff stay solid
   expect(page).not_to have_content(pick)

--- a/spec/support/matchers/ingest_form.rb
+++ b/spec/support/matchers/ingest_form.rb
@@ -8,7 +8,7 @@ def page_includes_ingest_fields_for?(group, type_pattern, value_pattern)
   for node in nodes
     within(node) do
       type_field = find("select.type-selector")
-      value_field = find("input.value-field")
+      value_field = find(".value-field")
 
       return true if type_pattern === type_field.value && value_pattern === value_field.value
     end


### PR DESCRIPTION
Fixes #701 indirectly.  Hard-codes a new ingest form group for collections (set and primary set) to use a dropdown instead of a text input.  The code is very special-case, and we'll probably want a better way to handle dropdowns more generally, but this will almost certainly deal with set typos, as nobody can directly type now.

This PR also does a little housekeeping on docker testing, which could be put into its own PR if desired; I just found some issues when testing that needed to be addressed.