### PR TITLE
Remove slashes from end of new properties

### DIFF
--- a/lib/oregon_digital/vocabularies/rights.rb
+++ b/lib/oregon_digital/vocabularies/rights.rb
@@ -6,8 +6,8 @@ module OregonDigital::Vocabularies
     # Other terms
     property :educational, :label => 'Educational Use Permitted'
     property :"orphan-work-us", :label => 'Orphan Work'
-    property :"rr-f/", :label => 'Rights Reserved - Free Access'
-    property :"rr-r/", :label => 'Rights Reserved - Restricted Access'
-    property :"unknown/", :label => 'Unknown'
+    property :"rr-f", :label => 'Rights Reserved - Free Access'
+    property :"rr-r", :label => 'Rights Reserved - Restricted Access'
+    property :"unknown", :label => 'Unknown'
   end
 end


### PR DESCRIPTION
I mistakenly added a slash at the end of the new properties, since the Europeana URIs had them. Our new ones don't.