### PR TITLE
Add batch directory for docker

### DIFF
--- a/batch/.gitignore
+++ b/batch/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       context: .
     volumes:
       - .:/oregondigital
+      - ./batch:/data1/batch
     entrypoint: ""
     command: bundle exec rake resque:work
     links:
@@ -61,6 +62,7 @@ services:
     volumes:
       - .:/oregondigital
       - ./docker/dev-entry.sh:/entrypoint.sh
+      - ./batch:/data1/batch
     ports:
       - "3000:3000"
     links:


### PR DESCRIPTION
Sets up docker-compose.yml to mount a local directory as the default batch directory, and adds that directory to the repo.