### PR TITLE
Changes Bulk Tasks to show recent, adds All page

### DIFF
--- a/app/controllers/bulk_tasks_controller.rb
+++ b/app/controllers/bulk_tasks_controller.rb
@@ -1,8 +1,13 @@
 class BulkTasksController < ApplicationController
   before_filter :restrict_to_archivist
-  before_filter :find_task, :except => :index
+  before_filter :find_task, :except => [:index, :all_tasks]
   
   def index
+    BulkTask.refresh
+    @tasks = BulkTaskDecorator.decorate_collection(BulkTask.includes(:bulk_task_children).last(30))
+  end
+
+  def all_tasks
     BulkTask.refresh
     @tasks = BulkTask.includes(:bulk_task_children).all.decorate
   end

--- a/app/views/bulk_tasks/all_tasks.html.erb
+++ b/app/views/bulk_tasks/all_tasks.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_title, "Batch Ingest" %>
 
 <div id="content" class="span12">
-<h2>Batch Ingest (Last 30)</h2>
-<p>Showing only the last 30 jobs. <%= link_to "See All Jobs", bulk_tasks_all_tasks_path %>.</p>
+<h2>Batch Ingest (All)</h2>
+<p>Showing all jobs.</p>
   <table class="table table-striped table-bordered table-condensed">
     <caption class="sr-only">Ingest Jobs</caption>
     <thead>
@@ -48,5 +48,4 @@
 <% end %>
   <tbody>
 </table>
-<p>Showing only the last 30 jobs. <%= link_to "See All Jobs", bulk_tasks_all_tasks_path %>.</p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,8 @@ Oregondigital::Application.routes.draw do
   resources :templates
 
   # Bulk Ingest Routes
-  resources :bulk_tasks, :only => [:index, :show, :update] do
+  get 'bulk_tasks/all_tasks', :to => 'bulk_tasks#all_tasks'
+  resources :bulk_tasks, :only => [:index, :show, :update, :all_tasks] do
     member do
       put '/ingest', :to => 'bulk_tasks#ingest'
       put '/reset', :to => 'bulk_tasks#reset_task'
@@ -46,6 +47,7 @@ Oregondigital::Application.routes.draw do
       delete '/stop_ingest', :to => 'bulk_tasks#stop_ingest'
     end
   end
+
   resources :bulk_task_children, :only => [:show]
 
   # Reviewer Controller Routes


### PR DESCRIPTION
No ticket for this but the Bulk Tasks main page takes way too long to render each time.

Changed the Bulk Tasks page to not show all entries, only the 30 most
recent ones. The full list is still available on a new page.