### PR TITLE
Fix/update ruby vips

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
 
       - run:
          name: Sudo
-         command: apt-get install -y sudo
+         command: |
+           apt-get update
+           apt-get install -y sudo
 
       - run:
           name: Services

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rails', '~> 4.2.0'
 
 gem 'mail', '~> 2.5.5'
-gem 'nokogiri', '~> 1.6.4'
+gem 'nokogiri', '~> 1.8.1'
 gem 'rest-client', '~> 1.7.3'
 gem 'sprockets', '~> 2.11.3'
 gem 'yard', '~> 0.9.11'
@@ -45,7 +45,7 @@ gem 'qa', :github => "oregondigital/questioning_authority", :branch => "fix/upda
 
 gem 'resque', '~>1.25.0'
 
-gem "ruby-vips", '~>1.0.6'
+gem "ruby-vips", '~>2.0.0'
 gem 'rmagick', '~>2.13.2'
 
 gem "devise", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,13 +248,8 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     fastercsv (1.5.5)
     ffi (1.9.0)
-    glib2 (3.1.8)
-      native-package-installer (>= 1.0.3)
-      pkg-config (>= 1.2.2)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    gobject-introspection (3.1.8)
-      glib2 (= 3.1.8)
     haml (4.0.5)
       tilt
     highline (1.7.8)
@@ -344,7 +339,6 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mysql2 (0.3.21)
-    native-package-installer (1.0.4)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -373,7 +367,6 @@ GEM
     orm_adapter (0.5.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
-    pkg-config (1.2.7)
     poltergeist (1.5.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -508,8 +501,8 @@ GEM
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
     ruby-filemagic (0.4.2)
-    ruby-vips (1.0.6)
-      gobject-introspection (~> 3.1)
+    ruby-vips (2.0.0)
+      ffi (~> 1.9)
     rubydora (1.7.4)
       activemodel
       activesupport
@@ -656,7 +649,7 @@ DEPENDENCIES
   mysql2 (~> 0.3.20)
   newrelic_rpm
   noid
-  nokogiri (~> 1.6.4)
+  nokogiri (~> 1.8.1)
   oai!
   poltergeist
   pry
@@ -679,7 +672,7 @@ DEPENDENCIES
   rspec-rails (~> 2.0)
   rspec_junit_formatter!
   ruby-filemagic (~> 0.4.2)
-  ruby-vips (~> 1.0.6)
+  ruby-vips (~> 2.0.0)
   sass-rails (~> 4.0.4)
   shoulda
   simple_form (~> 3.0.0)
@@ -695,4 +688,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/bin/vips_install.sh
+++ b/bin/vips_install.sh
@@ -133,8 +133,6 @@ case $(uname -s) in
           echo "Installing libvips dependencies via yum"
           yum groupinstall -y "Development Tools"
           yum install -y gtk-doc libxml2-devel libjpeg-turbo-devel libpng-devel libtiff-devel libexif-devel libgsf-devel lcms-devel ImageMagick-devel curl
-          yum install -y http://li.nux.ro/download/nux/dextop/el6/x86_64/nux-dextop-release-0-2.el6.nux.noarch.rpm
-          yum install -y --enablerepo=nux-dextop gobject-introspection-devel
           yum install -y http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
           yum install -y --enablerepo=remi libwebp-devel
           install_libvips_from_source "--prefix=/usr"


### PR DESCRIPTION
updating ruby-vips gets rid of the gobject-introspection dependency, which is preventing us from building on production.