### PR TITLE
Remove initialize and assign_subject that auto-creates URIs in Creator CV.

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/creator.rb
+++ b/lib/oregon_digital/controlled_vocabularies/creator.rb
@@ -28,24 +28,6 @@ module OregonDigital::ControlledVocabularies
       end
     end
 
-    def initialize(*args)
-      args[0] = assign_subject(args.first) unless args.first.to_s.start_with?("http")
-      super
-      if @new_label
-        self << RDF::Statement.new(rdf_subject, RDF::SKOS.prefLabel, @new_label)
-        @new_label = nil
-        persist!
-      end
-    end
-
-    def assign_subject(string)
-      string = string.to_s
-      new_subject = string.gsub(" ", "").gsub(/[^A-z]/,'').camelize
-      new_subject = OregonDigital::Vocabularies::DUMMYCREATOR.send(new_subject).to_s
-      @new_label = string
-      new_subject
-    end
-
     class QaLcNames < Qa::Authorities::Loc
       include OregonDigital::Qa::Caching
       def search(q, sub_authority=nil)


### PR DESCRIPTION
Fixes #1253 

Strings are rejected as not being in the CV now.

![image](https://user-images.githubusercontent.com/2293544/55039984-b1c29280-4fe3-11e9-9073-fa204afb9b49.png)
