### PR TITLE
Add loc_reponse_to_qa method

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/creator.rb
+++ b/lib/oregon_digital/controlled_vocabularies/creator.rb
@@ -33,6 +33,14 @@ module OregonDigital::ControlledVocabularies
       def search(q, sub_authority=nil)
         super(q, 'names')
       end
+
+      def loc_response_to_qa(data)
+        response = super(data)
+        for link in data.links
+          response["id"] = link[1] if link[0].nil?
+        end
+        return response
+      end
     end
 
     @qa_interface = QaLcNames.new


### PR DESCRIPTION
Fixes #1255 

This is the same method that the Subject CV has, forces use of the id.loc.gov links out of the JSON response that QA gets.

![image](https://user-images.githubusercontent.com/2293544/55106000-11c04400-508b-11e9-9c7d-299f18c9096f.png)
