### PR TITLE
Add RightsStatements.org vocabulary, add to CV.

### DIFF
--- a/config/initializers/controlled_vocabularies.rb
+++ b/config/initializers/controlled_vocabularies.rb
@@ -53,5 +53,6 @@ RDF_VOCABS = {
   :wikidata             =>  { :prefix => 'http://www.wikidata.org/entity/', :strict => false, :fetch => false},
   :lcgenreforms         =>  { :prefix => 'http://id.loc.gov/authorities/genreForms', :strict => false, :fetch => false },
   :osuacademicunits     =>  { :prefix => 'http://opaquenamespace.org/ns/osuAcademicUnits/', :strict => false, :fetch => false},
-  :seriesname           =>  { :prefix => 'http://opaquenamespace.org/ns/seriesName/', :strict => false, :fetch => false}
+  :seriesname           =>  { :prefix => 'http://opaquenamespace.org/ns/seriesName/', :strict => false, :fetch => false},
+  :rightsstatements     =>  { :prefix => 'http://rightsstatements.org/vocab/', :strict => false, :fetch => false}
 }

--- a/lib/oregon_digital/controlled_vocabularies/rights_statement.rb
+++ b/lib/oregon_digital/controlled_vocabularies/rights_statement.rb
@@ -2,11 +2,26 @@ module OregonDigital::ControlledVocabularies
   class RightsStatement < ActiveFedora::Rdf::Resource
     include OregonDigital::RDF::Controlled
 
-    configure :rdf_label => RDF::DC11.title
-
     use_vocabulary :rights
     use_vocabulary :cclicenses
     use_vocabulary :ccpublic
+    use_vocabulary :rightsstatements
 
+    # Custom fetch method for rightsstatement.org URIs
+    # Correct URI is /vocab, but /data is what responds with linked data
+    # For fetch purposes only, change URI from http://rightsstatements.org/vocab/InC-EDU/1.0/ to http://rightsstatements.org/data/InC-EDU/1.0.ttl
+    def fetch
+      if self.rdf_subject.to_s.include?('rightsstatements') then
+        self.rdf_subject.to_s.gsub!('vocab', 'data')
+        self.rdf_subject.to_s.gsub!(/\/$/, '.ttl')
+      end
+
+      super
+
+      if self.rdf_subject.to_s.include?('rightsstatements') then
+        self.rdf_subject.to_s.gsub!('data', 'vocab')
+        self.rdf_subject.to_s.gsub!('.ttl', '/')
+      end
+    end
   end
 end

--- a/lib/oregon_digital/vocabularies/rightsstatements.rb
+++ b/lib/oregon_digital/vocabularies/rightsstatements.rb
@@ -1,0 +1,17 @@
+require 'rdf'
+module OregonDigital::Vocabularies
+  class RIGHTSSTATEMENTS < ::RDF::StrictVocabulary("http://rightsstatements.org/vocab/")
+    property :"CNE/1.0/", :label => 'COPYRIGHT NOT EVALUATED'
+    property :"InC-EDU/1.0/", :label => 'IN COPYRIGHT - EDUCATIONAL USE PERMITTED'
+    property :"InC-NC/1.0/", :label => 'IN COPYRIGHT - NON-COMMERCIAL USE PERMITTED'
+    property :"InC-OW-EU/1.0/", :label => 'IN COPYRIGHT - EU ORPHAN WORK'
+    property :"InC-RUU/1.0/", :label => 'IN COPYRIGHT - RIGHTS-HOLDER(S) UNLOCATABLE OR UNIDENTIFIABLE'
+    property :"InC/1.0/", :label => 'IN COPYRIGHT'
+    property :"NKC/1.0/", :label => 'NO KNOWN COPYRIGHT'
+    property :"NoC-CR/1.0/", :label => 'NO COPYRIGHT - CONTRACTUAL RESTRICTIONS'
+    property :"NoC-NC/1.0/", :label => 'NO COPYRIGHT - NON-COMMERCIAL USE ONLY'
+    property :"NoC-OKLR/1.0/", :label => 'NO COPYRIGHT - OTHER KNOWN LEGAL RESTRICTIONS'
+    property :"NoC-US/1.0/", :label => 'NO COPYRIGHT - UNITED STATES'
+    property :"UND/1.0/", :label => 'COPYRIGHT UNDETERMINED'
+  end
+end


### PR DESCRIPTION
Fixes #1287 

Add RightsStatements.org vocabulary to the system, including the initializer, and add to the RightsStatement Controlled Vocabulary. Wrote custom fetch method to retrieve RDF from the /data URIs for labels.

```ruby
[10] pry(main)> rsnc = OregonDigital::ControlledVocabularies::RightsStatement.new (RDF::URI('http://rightsstatements.org/vocab/NoC-US/1.0/'))
=> #<OregonDigital::ControlledVocabularies::RightsStatement:0x2afddecdcfc4(default)>
[11] pry(main)> rsnc.rdf_label
=> ["http://rightsstatements.org/vocab/NoC-US/1.0/"]
[12] pry(main)> rsnc.fetch
=> nil
[13] pry(main)> rsnc.rdf_label
=> ["No Copyright - United States"]
```