### PR TITLE
Add Vocabulary and CV for Access Restrictions. Bump to ruby-vips.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'qa', :github => "oregondigital/questioning_authority", :branch => "fix/upda
 
 gem 'resque', '~>1.25.0'
 
-gem "ruby-vips", '~>2.0.11'
+gem "ruby-vips", '~>2.0.12'
 gem 'rmagick', '~>2.13.2'
 
 gem "devise", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,7 +509,7 @@ GEM
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
     ruby-filemagic (0.4.2)
-    ruby-vips (2.0.11)
+    ruby-vips (2.0.15)
       ffi (~> 1.9)
     rubydora (1.7.4)
       activemodel
@@ -685,7 +685,7 @@ DEPENDENCIES
   rspec-rails (~> 2.0)
   rspec_junit_formatter!
   ruby-filemagic (~> 0.4.2)
-  ruby-vips (~> 2.0.11)
+  ruby-vips (~> 2.0.12)
   sass-rails (~> 4.0.4)
   shoulda
   simple_form (~> 3.0.0)

--- a/app/models/datastream/oregon_rdf.rb
+++ b/app/models/datastream/oregon_rdf.rb
@@ -313,8 +313,8 @@ class Datastream::OregonRDF < OregonDigital::QuadResourceDatastream
   property :useRestrictions, :predicate => OregonDigital::Vocabularies::ARCHIVESHUB.useRestrictions do |index|
     index.as :searchable, :displayable
   end
-  property :accessRestrictions, :predicate => OregonDigital::Vocabularies::ARCHIVESHUB.accessRestrictions do |index|
-    index.as :searchable, :displayable
+  property :accessRestrictions, :predicate => OregonDigital::Vocabularies::ARCHIVESHUB.accessRestrictions, :class_name => OregonDigital::ControlledVocabularies::AccessRestrictions do |index|
+    index.as :searchable, :facetable, :displayable
   end
   property :license, :predicate => OregonDigital::Vocabularies::CCREL.license, :class_name => OregonDigital::ControlledVocabularies::License do |index|
     index.as :searchable, :facetable, :displayable

--- a/config/initializers/controlled_vocabularies.rb
+++ b/config/initializers/controlled_vocabularies.rb
@@ -54,5 +54,6 @@ RDF_VOCABS = {
   :lcgenreforms         =>  { :prefix => 'http://id.loc.gov/authorities/genreForms', :strict => false, :fetch => false },
   :osuacademicunits     =>  { :prefix => 'http://opaquenamespace.org/ns/osuAcademicUnits/', :strict => false, :fetch => false},
   :seriesname           =>  { :prefix => 'http://opaquenamespace.org/ns/seriesName/', :strict => false, :fetch => false},
-  :rightsstatements     =>  { :prefix => 'http://rightsstatements.org/vocab/', :strict => false, :fetch => false}
+  :rightsstatements     =>  { :prefix => 'http://rightsstatements.org/vocab/', :strict => false, :fetch => false},
+  :accessrestrict       =>  { :prefix => 'http://opaquenamespace.org/ns/accessRestrictions/', :strict => false, :fetch => false}
 }

--- a/lib/oregon_digital/controlled_vocabularies/access_restrictions.rb
+++ b/lib/oregon_digital/controlled_vocabularies/access_restrictions.rb
@@ -1,0 +1,9 @@
+module OregonDigital::ControlledVocabularies
+  class AccessRestrictions < ActiveFedora::Rdf::Resource
+    include OregonDigital::RDF::Controlled
+
+    use_vocabulary :accessrestrict
+
+  end
+end
+

--- a/lib/oregon_digital/vocabularies/accessrestrict.rb
+++ b/lib/oregon_digital/vocabularies/accessrestrict.rb
@@ -1,0 +1,5 @@
+module OregonDigital::Vocabularies
+  class ACCESSRESTRICT < ::RDF::Vocabulary("http://opaquenamespace.org/ns/accessRestrictions/")
+  end
+end
+


### PR DESCRIPTION
Fixes #1292 

Creates a new vocabulary for Access Restrictions at opaquenamespace.org, and then adds that to a new Controlled Vocabulary, which is then applied to the accessRestrictions fields. The values are set to facet as well.

Also a small bump to ruby-vips, the original version was not installing/building any more.

Access Restrictions field now controlled with both values:
![image](https://user-images.githubusercontent.com/2293544/70192842-f1349900-16b1-11ea-9ea1-06f5b88c58f8.png)

Facet:
![image](https://user-images.githubusercontent.com/2293544/70192850-ff82b500-16b1-11ea-9bc4-a58efc5b50e3.png)
