### PR TITLE
Add quotes around alt and title attributes.

### DIFF
--- a/app/views/catalog/_small_image_viewer.html.erb
+++ b/app/views/catalog/_small_image_viewer.html.erb
@@ -3,7 +3,7 @@
 <div align="center">
   <div id="small-image-viewer">
     <img src="/media/medium-images/<%= decorated_object.relative_medium_image_location %>"
-        alt=<%= decorated_object.title %>
-        title=<%= decorated_object.title %>>
+        alt="<%= decorated_object.title %>"
+        title="<%= decorated_object.title %>">
   </div>
 </div>


### PR DESCRIPTION
Fixes #1303 

I can't take a screenshot with the image title popup, but result code is:
```html
<div id="small-image-viewer">
  <img src="/media/medium-images/8/9/oregondigital-j67331498.jpg"
    alt="Test jpg viewer alt text - Heathman Hotel"
    title="Test jpg viewer alt text - Heathman Hotel">
</div>
```
