### PR TITLE
Add Publisher vocab and CV, make field controlled.

### DIFF
--- a/app/models/datastream/oregon_rdf.rb
+++ b/app/models/datastream/oregon_rdf.rb
@@ -329,7 +329,7 @@ class Datastream::OregonRDF < OregonDigital::QuadResourceDatastream
   property :language, :predicate => RDF::DC.language, :class_name => OregonDigital::ControlledVocabularies::Language do |index|
     index.as :displayable, :facetable
   end
-  property :publisher, :predicate => RDF::DC.publisher do |index|
+  property :publisher, :predicate => RDF::DC.publisher, :class_name => OregonDigital::ControlledVocabularies::Publisher do |index|
     index.as :searchable, :facetable, :displayable
   end
   property :placeOfPublication, :predicate => OregonDigital::Vocabularies::MARCREL.pup, :class_name => OregonDigital::ControlledVocabularies::Geographic do |index|

--- a/config/initializers/controlled_vocabularies.rb
+++ b/config/initializers/controlled_vocabularies.rb
@@ -55,5 +55,6 @@ RDF_VOCABS = {
   :osuacademicunits     =>  { :prefix => 'http://opaquenamespace.org/ns/osuAcademicUnits/', :strict => false, :fetch => false},
   :seriesname           =>  { :prefix => 'http://opaquenamespace.org/ns/seriesName/', :strict => false, :fetch => false},
   :rightsstatements     =>  { :prefix => 'http://rightsstatements.org/vocab/', :strict => false, :fetch => false},
-  :accessrestrict       =>  { :prefix => 'http://opaquenamespace.org/ns/accessRestrictions/', :strict => false, :fetch => false}
+  :accessrestrict       =>  { :prefix => 'http://opaquenamespace.org/ns/accessRestrictions/', :strict => false, :fetch => false},
+  :publisher            =>  { :prefix => 'http://opaquenamespace.org/ns/publisher/', :strict => false, :fetch => false}
 }

--- a/lib/oregon_digital/controlled_vocabularies/publisher.rb
+++ b/lib/oregon_digital/controlled_vocabularies/publisher.rb
@@ -1,0 +1,33 @@
+module OregonDigital::ControlledVocabularies
+  class Publisher < ActiveFedora::Rdf::Resource
+    include OregonDigital::RDF::Controlled
+
+    use_vocabulary :lcnames
+    use_vocabulary :ulan
+    use_vocabulary :publisher
+    use_vocabulary :creator
+    use_vocabulary :wikidata
+    use_vocabulary :osuacademicunits
+
+    # Make wikidata entity URIs usable to fetch.
+    # Our gems don't handle their https redirect, and JSON is the default response which we have errors parsing, so force to NT.
+    # For fetch purposes only, change URI from http://www.wikidata.org/entity/Q5343795 to https://www.wikidata.org/wiki/Special:EntityData/Q5343795.nt
+    def fetch
+      if self.rdf_subject.to_s.include?('wikidata') then
+        self.rdf_subject.to_s.gsub!('http://www.wikidata.org/entity/', 'https://www.wikidata.org/wiki/Special:EntityData/')
+        self.rdf_subject.to_s.concat('.nt')
+      elsif self.rdf_subject.to_s.include?('loc.gov') then
+        self.rdf_subject.to_s.gsub!('http', 'https')
+      end
+
+      super
+
+      if self.rdf_subject.to_s.include?('wikidata') then
+        self.rdf_subject.to_s.gsub!('https://www.wikidata.org/wiki/Special:EntityData/', 'http://www.wikidata.org/entity/')
+        self.rdf_subject.to_s.gsub!('.nt', '')
+      elsif self.rdf_subject.to_s.include?('loc.gov') then
+        self.rdf_subject.to_s.gsub!('https', 'http')
+      end
+    end
+  end
+end

--- a/lib/oregon_digital/oai/concern.rb
+++ b/lib/oregon_digital/oai/concern.rb
@@ -12,8 +12,8 @@ module OregonDigital::OAI::Concern
     def uri_fields
       @uri_fields = [:creator, :lcsubject, :type, :author, :editor, :photographer, :phylum, :taxonClass, :order, :family,
                      :genus, :species, :commonNames, :arranger, :artist, :author, :collector, :composer, :contributor, :illustrator,
-                     :interviewee, :interviewer, :lyricist, :photographer, :translator, :owner, :designer, :ethnographicTerm, :militaryBranch, :stylePeriod, 
-                     :language, :localCollectionName, :od_repository, :recipient, :set]
+                     :interviewee, :interviewer, :lyricist, :photographer, :translator, :owner, :designer, :ethnographicTerm, :militaryBranch, :stylePeriod,
+                     :language, :localCollectionName, :od_repository, :recipient, :set, :publisher]
     end
 
     # Map Qualified Dublin Core (Terms) fields to Oregon Digital fields

--- a/lib/oregon_digital/vocabularies/publisher.rb
+++ b/lib/oregon_digital/vocabularies/publisher.rb
@@ -1,0 +1,5 @@
+require 'rdf'
+module OregonDigital::Vocabularies
+  class PUBLISHER < ::RDF::Vocabulary("http://opaquenamespace.org/ns/publisher/")
+  end
+end


### PR DESCRIPTION
For part of #898 

Create Publisher vocabulary and Publisher controlled vocabulary with several vocabs, and make the field use that new CV.

![image](https://user-images.githubusercontent.com/2293544/106790602-a3deef00-6608-11eb-97de-c5796a15cfba.png)
