### PR TITLE
update bag_info date

### DIFF
--- a/lib/hyrax/migrator/export.rb
+++ b/lib/hyrax/migrator/export.rb
@@ -84,7 +84,9 @@ module Hyrax::Migrator
     end
 
     def bag_finisher(bag)
-      bag.write_bag_info
+      info = bag.bag_info
+      info['Bagging-Date'] = Date.today.strftime("%Y-%m-%d")
+      bag.write_bag_info info
       bag.tagmanifest!
       bag.manifest!
     end


### PR DESCRIPTION
In export.rb, the bag_finisher method is for updating the bag after changes have been made.
I thought that the BagIt method write_bag_info updated the bag-info, but not on its own. This PR inserts a few lines of code in bag_finisher to set the date to current date before calling write_bag_info.