### PR TITLE
Update ruby-oai gem, had gone back too old before.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'mysql2', '~>0.3.20'
 gem 'puma'
 
 # OAI
-gem 'oai', :git => "https://github.com/code4lib/ruby-oai", tag: 'v0.3.1'
+gem 'oai', :git => "https://github.com/code4lib/ruby-oai", tag: 'v0.4.0'
 
 # Old Asset Precompile Behavior for Stylesheets
 gem "sprockets-digest-assets-fix", :git => "https://github.com/tobiasr/sprockets-digest-assets-fix"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,11 +57,11 @@ GIT
 
 GIT
   remote: https://github.com/code4lib/ruby-oai
-  revision: 1bc409da9c7319d4f9ba5b835ed41fc49b4e0fd7
-  tag: v0.3.1
+  revision: 52aa1cc0d3d2a250f0d4480e0be32f13d8c97692
+  tag: v0.4.0
   specs:
-    oai (0.3.1)
-      builder (>= 2.0.0)
+    oai (0.4.0)
+      builder (>= 3.1.0)
       faraday
       faraday_middleware
 

--- a/config/app.yml.default
+++ b/config/app.yml.default
@@ -2,7 +2,7 @@ id_namespace: oregondigital
 minter_statefile: 'tmp/minter-state'
 uri_base:
   oregondigital: 'http://oregondigital.org/resource/'
-set_content_repo: "git://github.com/OregonDigital/oregon-digital-set-content.git"
+set_content_repo: "https://github.com/OregonDigital/oregon-digital-set-content.git"
 secret_key_base: 'b16037becb6710bc72b7691310c78307b529be854e2ed40685b23abcbe3f20382a53eff24593d6077b037b1219effa7823d8b608b6cd10451c6a69da145014471'
 devise:
   secret: 'd330c022c85eeab638dc59efaac57ajasdfja79c254e64dcc9a83635f218d20f30c65854e0df366c5b303e38dcabfc0dc4b585cd247a147c48f5420a95ff9ad8'

--- a/spec/factories/generic_asset.rb
+++ b/spec/factories/generic_asset.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
   factory :generic_asset, parent: :active_fedora_base, class: GenericAsset do
     sequence(:title) {|n| "Generic Asset #{n}"}
     read_groups ["public"]
-    sequence(:created) { |n| (Date.today - 1000 + n).to_s }
+    sequence(:created) { |n| (Date.today - 900 + n).to_s }
 
     after(:build) {|obj| obj.review}
 

--- a/spec/models/generic_asset_spec.rb
+++ b/spec/models/generic_asset_spec.rb
@@ -85,7 +85,7 @@ describe GenericAsset, :resque => true do
         # created date set by factory
         let(:date) { nil }
         it "should be that decade" do
-           expect(facet).to eq ["2010-2019"]
+           expect(facet).to eq ["2020-2029"]
         end
       end
     end


### PR DESCRIPTION
Also update set-content github repo to https.
Factory for generic asset was making a created date of now - 1000 days + a sequence counter. That date was now either at the end of 2019 (ok) or start of 2020 (not ok), which affected the date decade facet checking for 2010-2019.